### PR TITLE
Add heuristic to fuse conv2d with tensor add

### DIFF
--- a/include/xten/Conversion/ATenToXTen.td
+++ b/include/xten/Conversion/ATenToXTen.td
@@ -78,6 +78,11 @@ def : Pat<(Torch_AtenMulTensorOp $a, $b),
 def : Pat<(Torch_AtenAddTensorOp $a, $b, $c),
           (XTen_AddOp $a, $b)>;
 
+// prefer fusing with the right input if the attribute is present
+def : Pat<(XTen_AddOp $h, (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g, AnyAttr:$_internal_xten_fuse_with_tensoradd)),
+          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+// otherwise fuse with the left one
 def : Pat<(XTen_AddOp (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g), $h),
           (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
 

--- a/include/xten/Conversion/ATenToXTen.td
+++ b/include/xten/Conversion/ATenToXTen.td
@@ -15,6 +15,8 @@ include "torch-mlir/Dialect/Torch/IR/TorchOps.td"
 
 include "xten/Dialect/XTen/XTenOps.td"
 
+// note: this pass is complemented by XTenFusions.td
+
 // Normalize names, so that we only have to write one pattern.
 // Each operator comes in two variants, eg torch.aten.relu and torch.aten.relu_ (with underscore)
 // PyTorch operators have an in-place variant and a by-return variant,

--- a/include/xten/Conversion/ATenToXTen.td
+++ b/include/xten/Conversion/ATenToXTen.td
@@ -78,16 +78,3 @@ def : Pat<(Torch_AtenMulTensorOp $a, $b),
 def : Pat<(Torch_AtenAddTensorOp $a, $b, $c),
           (XTen_AddOp $a, $b)>;
 
-// prefer fusing with the right input if the attribute is present
-def : Pat<(XTen_AddOp $h, (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g, AnyAttr:$_internal_xten_fuse_with_tensoradd)),
-          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
-
-// otherwise fuse with the left one
-def : Pat<(XTen_AddOp (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g), $h),
-          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
-
-def : Pat<(Torch_AtenReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)),
-          (XTen_Conv2dTensorAddReLUOp $a,$b,$c,$d,$e,$f,$g,$h)>;
-
-def : Pat<(Torch_AtenLeakyReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h), $alpha),
-          (XTen_Conv2dTensorAddLReLUOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)>;

--- a/include/xten/Conversion/ATenToXTen2ndRound.td
+++ b/include/xten/Conversion/ATenToXTen2ndRound.td
@@ -15,7 +15,18 @@ include "torch-mlir/Dialect/Torch/IR/TorchOps.td"
 
 include "xten/Dialect/XTen/XTenOps.td"
 
-// This conversion operates XTen -> XTen, after the initial ATen -> XTen.
+// These patterns perform XTen -> XTen fusions, after the initial ATen -> XTen.
+// These patterns apply on fully legalized XTen to avoid situations where an ATen op
+// matches a catch-all pattern. For instance, if the two following patterns
+//  (XTen_AddOp (XTen_Conv2dOp) $other)
+//  (XTen_AddOp (XTen_Conv2dOp) (XTen_Conv2dOp))
+// were applied in the ATenToXTen pass directly, `$other` could match an `aten.conv2d`
+// which has not been legalized to an `XTen_Conv2dOp` yet. If it had been legalized then
+// the second pattern would match, not the first. The driver does this because it considers
+// large matches before small ones, so the first pattern above is preferred to just
+// `aten.conv2d -> xten.conv2d` which touches only one op.
+// This problem is avoided by applying all simple conversions first, then doing more fusions
+// on pure XTen here.
 
 
 def SelectFirstC2dInSymmetricTensorAdd : Constraint<

--- a/include/xten/Conversion/ATenToXTen2ndRound.td
+++ b/include/xten/Conversion/ATenToXTen2ndRound.td
@@ -1,0 +1,51 @@
+//===- ATenToXTen.td ---------------------------------------*- tablegen -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2020 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/IR/OpBase.td"
+include "mlir/Dialect/StandardOps/IR/Ops.td"
+
+include "torch-mlir/Dialect/Torch/IR/TorchOps.td"
+
+include "xten/Dialect/XTen/XTenOps.td"
+
+// This conversion operates XTen -> XTen, after the initial ATen -> XTen.
+
+
+def SelectFirstC2dInSymmetricTensorAdd : Constraint<
+    CPred<"fuseFirstC2dInTensorAdd($0, $1)">,
+    "fuse first parameter into tensor add, otherwise fuse second.">;
+
+// This pattern catches the case where 2 conv2ds are inputs to an add.
+// Then we callback `fuseFirstC2dInTensorAdd` to find which one to fuse.
+// If the callback is true (left c2d needs to be fused) then the pattern is applied.
+// Otherwise another pattern is applied (benefits care about that).
+def : Pat<(XTen_AddOp (XTen_Conv2dOp:$c2d0 $a,$b,$c,$d,$e,$f,$g), (XTen_Conv2dOp:$c2d1 $_,$_,$_,$_,$_,$_,$_)),
+          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g, $c2d1),
+          [(SelectFirstC2dInSymmetricTensorAdd $c2d0, $c2d1)],
+          (addBenefit 3)>;
+
+def : Pat<(XTen_AddOp (XTen_Conv2dOp:$c2d0 $_,$_,$_,$_,$_,$_,$_), (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g)),
+          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g, $c2d0),
+          [],
+          (addBenefit 2)>;
+
+def : Pat<(XTen_AddOp $h, (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g)),
+          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+def : Pat<(XTen_AddOp (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g), $h),
+          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+// these add an activation after the tensoradd
+
+def : Pat<(Torch_AtenReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)),
+          (XTen_Conv2dTensorAddReLUOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+def : Pat<(Torch_AtenLeakyReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h), $alpha),
+          (XTen_Conv2dTensorAddLReLUOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)>;

--- a/include/xten/Conversion/CMakeLists.txt
+++ b/include/xten/Conversion/CMakeLists.txt
@@ -13,8 +13,8 @@ set(LLVM_TARGET_DEFINITIONS ATenToXTen.td)
 mlir_tablegen(ATenToXTen.cpp.inc -gen-rewriters)
 add_public_tablegen_target(ATenToXTenIncGen)
 
-set(LLVM_TARGET_DEFINITIONS ATenToXTen2ndRound.td)
-mlir_tablegen(ATenToXTen2ndRound.cpp.inc -gen-rewriters)
+set(LLVM_TARGET_DEFINITIONS XTenFusions.td)
+mlir_tablegen(XTenFusions.cpp.inc -gen-rewriters)
 add_public_tablegen_target(ATenToXTenIncGen2)
 
 add_mlir_doc(Passes XTenConversionPasses ./ -gen-pass-doc)

--- a/include/xten/Conversion/CMakeLists.txt
+++ b/include/xten/Conversion/CMakeLists.txt
@@ -13,4 +13,8 @@ set(LLVM_TARGET_DEFINITIONS ATenToXTen.td)
 mlir_tablegen(ATenToXTen.cpp.inc -gen-rewriters)
 add_public_tablegen_target(ATenToXTenIncGen)
 
+set(LLVM_TARGET_DEFINITIONS ATenToXTen2ndRound.td)
+mlir_tablegen(ATenToXTen2ndRound.cpp.inc -gen-rewriters)
+add_public_tablegen_target(ATenToXTenIncGen2)
+
 add_mlir_doc(Passes XTenConversionPasses ./ -gen-pass-doc)

--- a/include/xten/Conversion/XTenFusions.td
+++ b/include/xten/Conversion/XTenFusions.td
@@ -36,7 +36,7 @@ def SelectFirstC2dInSymmetricTensorAdd : Constraint<
 // This pattern catches the case where 2 conv2ds are inputs to an add.
 // Then we callback `fuseFirstC2dInTensorAdd` to find which one to fuse.
 // If the callback is true (left c2d needs to be fused) then the pattern is applied.
-// Otherwise another pattern is applied (benefits care about that).
+// Otherwise another pattern is applied (benefits take care of that).
 def : Pat<(XTen_AddOp (XTen_Conv2dOp:$c2d0 $a,$b,$c,$d,$e,$f,$g), (XTen_Conv2dOp:$c2d1 $_,$_,$_,$_,$_,$_,$_)),
           (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g, $c2d1),
           [(SelectFirstC2dInSymmetricTensorAdd $c2d0, $c2d1)],

--- a/include/xten/Conversion/XTenFusions.td
+++ b/include/xten/Conversion/XTenFusions.td
@@ -1,4 +1,4 @@
-//===- ATenToXTen.td ---------------------------------------*- tablegen -*-===//
+//===- XTenFusions.td --------------------------------------*- tablegen -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -83,7 +83,7 @@ namespace atenToXten {
 }
 
 namespace xtenToXtenCleanup {
-#include "xten/Conversion/ATenToXTen2ndRound.cpp.inc"
+#include "xten/Conversion/XTenFusions.cpp.inc"
 }
 
 

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -47,7 +47,6 @@
 #define DEBUG_TYPE "aten-to-xten-pass"
 
 using namespace mlir;
-// using namespace xilinx::xten;
 using namespace xilinx;
 using namespace mlir::torch;
 
@@ -60,8 +59,8 @@ long getInputSize(xten::Conv2dOp &c2d) {
   auto shape = inputType.getShape();
   // multiply all dimensions together
   long result = 1;
-  for (auto it = shape.begin(); it != shape.end(); it++)
-    result *= *it;
+  for (auto i: shape)
+    result *= i;
   return result;
 }
 

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -16,14 +16,14 @@
 #include "xten/Dialect/XTen/XTenDialect.h"
 #include "xten/Dialect/XTen/XTenOps.h"
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -48,32 +48,109 @@
 
 using namespace mlir;
 using namespace xilinx::xten;
+using namespace mlir::torch::Torch;
 
 namespace {
 
 #include "xten/Conversion/ATenToXTen.cpp.inc"
 
+/*
+
+def : Pat<(XTen_AddOp (XTen_Conv2dOp $a,$b,$c,$d,$e,$f,$g), $h),
+          (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+*/
+
+namespace {
+
+struct OpRefPair {
+  AtenConv2dOp *toFuse;
+  Operation *other;
+};
+
+} // namespace
+
+class AtenConv2dAnnotator : public OpConversionPattern<AtenAddTensorOp> {
+public:
+  explicit AtenConv2dAnnotator(MLIRContext *context)
+      : OpConversionPattern<AtenAddTensorOp>(context, 15) {}
+
+  LogicalResult
+  matchAndRewrite(AtenAddTensorOp tensorAdd, OpAdaptor adapter,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    auto operands = adapter.getOperands();
+    auto op0source = operands[0].getDefiningOp();
+    auto op1source = operands[1].getDefiningOp();
+
+    if (!op0source || !op1source ||
+        (!isa<AtenConv2dOp>(op0source) && !isa<AtenConv2dOp>(op1source)))
+      return rewriter.notifyMatchFailure(
+          tensorAdd, "only finds tensorAdd with 1..2 conv2d inputs");
+
+    auto [opToFuse, otherOperand] =
+        selectOpsToFuseBeforeTensorAdd(op0source, op1source);
+
+    rewriter.replaceOpWithNewOp<xilinx::xten::Conv2dTensorAddOp>(
+      tensorAdd,
+      
+    );
+
+    return success();
+  }
+
+private:
+  bool shouldFuseFirstConv2d(AtenConv2dOp &c2d0, AtenConv2dOp &c2d1) const {
+    auto input0 = c2d0.input();
+    auto input1 = c2d1.input();
+
+    // todo compare input size
+
+    return false;
+  }
+
+  OpRefPair selectOpsToFuseBeforeTensorAdd(Operation *op0source,
+                                           Operation *op1source) const {
+
+    bool shouldFuseFirst = isa<AtenConv2dOp>(op0source);
+
+    if (isa<AtenConv2dOp>(op0source) && isa<AtenConv2dOp>(op1source)) {
+      // both are fusable
+      auto op0 = cast<AtenConv2dOp>(op0source);
+      auto op1 = cast<AtenConv2dOp>(op1source);
+      shouldFuseFirst = shouldFuseFirstConv2d(op0, op1);
+    }
+
+    if (shouldFuseFirst) {
+      return OpRefPair{.toFuse = dynamic_cast<AtenConv2dOp*>(op0source), .other = op1source};
+    } else {
+      return OpRefPair{.toFuse = dynamic_cast<AtenConv2dOp*>(op1source), .other = op0source};
+    }
+  }
+};
+
 struct ATenToXTenPass : public ATenToXTenBase<ATenToXTenPass> {
 
-  void getDependentDialects(::mlir::DialectRegistry &registry) const override {  
-     registry.insert<xilinx::xten::XTenDialect>();
-     registry.insert<memref::MemRefDialect>();
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<xilinx::xten::XTenDialect>();
+    registry.insert<memref::MemRefDialect>();
   }
 
   void runOnOperation() override {
 
     auto module = getOperation();
     auto context = module.getContext();
-    
+
     // tablegen patterns
     RewritePatternSet fusionPatterns(&getContext());
+    fusionPatterns.add<AtenConv2dAnnotator>(context);
     populateWithGenerated(fusionPatterns);
 
     // Perform aten specific Fusion.
     ConversionTarget target(*context);
 
-    target.addLegalDialect<AffineDialect, LLVM::LLVMDialect,
-                           StandardOpsDialect, scf::SCFDialect>();
+    target.addLegalDialect<AffineDialect, LLVM::LLVMDialect, StandardOpsDialect,
+                           scf::SCFDialect>();
 
     target.addLegalOp<xilinx::xten::Conv2dBatchNormReLUOp>();
     target.addLegalOp<xilinx::xten::Conv2dReLUOp>();
@@ -84,23 +161,22 @@ struct ATenToXTenPass : public ATenToXTenBase<ATenToXTenPass> {
     target.addLegalOp<xilinx::xten::Conv2dTensorAddReLUOp>();
     target.addLegalOp<xilinx::xten::Conv2dTensorAddLReLUOp>();
     target.addLegalOp<xilinx::xten::NoOp>();
-    if (failed(applyPatternsAndFoldGreedily(module, /*target,*/ std::move(fusionPatterns)))) {
-      emitError(UnknownLoc::get(context), "error translating or fusing ATen to XTen\n");
+    if (failed(applyPatternsAndFoldGreedily(
+            module, /*target,*/ std::move(fusionPatterns)))) {
+      emitError(UnknownLoc::get(context),
+                "error translating or fusing ATen to XTen\n");
       signalPassFailure();
       assert(0);
     }
-
   }
 };
 
-}// namespace
-
+} // namespace
 
 namespace xilinx {
 namespace xten {
 
-std::unique_ptr<OperationPass<ModuleOp>>
-createATenToXTenPass() {
+std::unique_ptr<OperationPass<ModuleOp>> createATenToXTenPass() {
   return std::make_unique<ATenToXTenPass>();
 }
 

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -64,8 +64,11 @@ long getInputSize(xten::Conv2dOp &c2d) {
   return result;
 }
 
-// pick conv2d with smallest input size.
-bool fuseFirstC2dInTensorAdd(xten::Conv2dOp &c2d0, xten::Conv2dOp &c2d1) {
+// Pick conv2d with smallest input size, because we expect that this one will need less L1 storage
+// The goal is to minimize memory transfers.
+// This might not be the best implementation, may be
+// improved later when more low-level details are known.
+bool fuseFirstC2dInTensorAddImpl(xten::Conv2dOp &c2d0, xten::Conv2dOp &c2d1) {
   auto s0 = getInputSize(c2d0);
   auto s1 = getInputSize(c2d1);  
   return s0 && s1 && s0 < s1;
@@ -74,7 +77,7 @@ bool fuseFirstC2dInTensorAdd(xten::Conv2dOp &c2d0, xten::Conv2dOp &c2d1) {
 bool fuseFirstC2dInTensorAdd(OpResult a, OpResult b) {
   auto c2d0 = cast<xten::Conv2dOp>(a.getOwner());
   auto c2d1 = cast<xten::Conv2dOp>(b.getOwner());
-  return fuseFirstC2dInTensorAdd(c2d0, c2d1);
+  return fuseFirstC2dInTensorAddImpl(c2d0, c2d1);
 }
 
 namespace atenToXten {

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -15,6 +15,7 @@ DEPENDS
 XTenConversionIncGen
 XTenDialect
 ATenToXTenIncGen
+ATenToXTenIncGen2
 
 LINK_COMPONENTS
 Core

--- a/test/Conversion/ATenToXTen/aten_double_conv2d_add.mlir
+++ b/test/Conversion/ATenToXTen/aten_double_conv2d_add.mlir
@@ -1,0 +1,38 @@
+//===- aten_conv2d_nobias.mlir ---------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2019 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aten-opt %s -aten-to-xten | FileCheck %s
+// CHECK: %[[INT1:.*]] = torch.constant.int 1
+// CHECK: %[[INT2:.*]] = torch.constant.int 2
+// CHECK: %[[INT1L:.*]] = torch.prim.ListConstruct %[[INT1]], %[[INT1]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK: %[[INT2L:.*]] = torch.prim.ListConstruct %[[INT2]], %[[INT2]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK: %[[C2D:.*]] = "xten.conv2d"(%[[IN1:.*]], %0, %none, %[[INT1L]], %[[INT1L]], %[[INT2L]], %[[INT1]]) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,2,128,128],f32>
+// CHECK: %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu"(%[[IN2:.*]], %0, %none, %[[INT1L]], %[[INT1L]], %[[INT1L]], %[[INT1]], %float4.000000e-01, %[[C2D]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
+module attributes {torch.debug_module_name = "model"}  {
+  func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %alpha = torch.constant.float 0.4
+    %0 = torch.vtensor.literal(dense<"0xDEADBEEF"> : tensor<16x2x3x3xf32>) : !torch.vtensor<[16,2,3,3],f32>
+    %none = torch.constant.none
+    %int1List = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %stride2 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+
+    %largeTensor = torch.vtensor.literal(dense<"0xDEADBEEF"> : tensor<1x2x256x256xf32>) : !torch.vtensor<[1,2,256,256],f32>
+    // this one gets fused
+    %c2d1 = torch.aten.conv2d %arg0, %0, %none, %int1List, %int1List, %int1List, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+    // not this one
+    %c2d2 = torch.aten.conv2d %largeTensor, %0, %none, %int1List, %int1List, %stride2, %int1 : !torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+
+    %7 = torch.aten.add.Tensor %c2d2, %c2d1, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[1,2,128,128],f32>, !torch.int ->  !torch.vtensor<[1,2,128,128],f32>
+    %8 = torch.aten.leaky_relu %7, %alpha : !torch.vtensor<[1,2,128,128],f32>, !torch.float -> !torch.vtensor<[1,2,128,128],f32>
+    return %8 : !torch.vtensor<[1,2,128,128],f32>
+  }
+}

--- a/test/Conversion/ATenToXTen/aten_double_conv2d_add_reversed.mlir
+++ b/test/Conversion/ATenToXTen/aten_double_conv2d_add_reversed.mlir
@@ -1,0 +1,38 @@
+//===- aten_conv2d_nobias.mlir ---------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2019 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aten-opt %s -aten-to-xten | FileCheck %s
+// CHECK: %[[INT1:.*]] = torch.constant.int 1
+// CHECK: %[[INT2:.*]] = torch.constant.int 2
+// CHECK: %[[INT1L:.*]] = torch.prim.ListConstruct %[[INT1]], %[[INT1]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK: %[[INT2L:.*]] = torch.prim.ListConstruct %[[INT2]], %[[INT2]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK: %[[C2D:.*]] = "xten.conv2d"(%[[IN1:.*]], %0, %none, %[[INT1L]], %[[INT1L]], %[[INT2L]], %[[INT1]]) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,2,128,128],f32>
+// CHECK: %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu"(%[[IN2:.*]], %0, %none, %[[INT1L]], %[[INT1L]], %[[INT1L]], %[[INT1]], %float4.000000e-01, %[[C2D]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
+module attributes {torch.debug_module_name = "model"}  {
+  func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %alpha = torch.constant.float 0.4
+    %0 = torch.vtensor.literal(dense<"0xDEADBEEF"> : tensor<16x2x3x3xf32>) : !torch.vtensor<[16,2,3,3],f32>
+    %none = torch.constant.none
+    %int1List = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %stride2 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+
+    %largeTensor = torch.vtensor.literal(dense<"0xDEADBEEF"> : tensor<1x2x256x256xf32>) : !torch.vtensor<[1,2,256,256],f32>
+    // this one gets fused
+    %c2d1 = torch.aten.conv2d %arg0, %0, %none, %int1List, %int1List, %int1List, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+    // not this one
+    %c2d2 = torch.aten.conv2d %largeTensor, %0, %none, %int1List, %int1List, %stride2, %int1 : !torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+    // the operands are reversed here
+    %7 = torch.aten.add.Tensor %c2d1, %c2d2, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[1,2,128,128],f32>, !torch.int ->  !torch.vtensor<[1,2,128,128],f32>
+    %8 = torch.aten.leaky_relu %7, %alpha : !torch.vtensor<[1,2,128,128],f32>, !torch.float -> !torch.vtensor<[1,2,128,128],f32>
+    return %8 : !torch.vtensor<[1,2,128,128],f32>
+  }
+}


### PR DESCRIPTION
The ATen->XTen pass now has 2 phases:
- ATen -> XTen proper
- XTen -> XTen where we perform additional fusions. In particular this is where the conv+add fusion is performed. 

Without this I was hitting weird cases whereby MLIR only converts one operand of `add` to XTen (the other operand still being an ATen op), and then applies the wrong pattern.