### PR TITLE
FXML-766: Small fixes

### DIFF
--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -97,9 +97,9 @@ bool isLongestBranch(OpResult left, OpResult right) {
   while (!worklist.empty()) {
     auto curOp = opDistanceMap.find(worklist.front());
     SmallVector<Operation *> inputOps = getUsefulInputOps(curOp->first);
+    unsigned nextDistance = curOp->second + 1;
 
     for (Operation *inputOp : inputOps) {
-      unsigned nextDistance = curOp->second + 1;
       auto inputOpDistancePair = opDistanceMap.find(inputOp);
       if (inputOpDistancePair == opDistanceMap.end()) {
         worklist.push_back(inputOp);
@@ -119,9 +119,9 @@ bool isLongestBranch(OpResult left, OpResult right) {
   while (!worklist.empty()) {
     auto curOp = opDistanceMap.find(worklist.front());
     SmallVector<Operation *> inputOps = getUsefulInputOps(curOp->first);
+    unsigned nextDistance = curOp->second + 1;
 
     for (Operation *inputOp : inputOps) {
-      unsigned nextDistance = curOp->second + 1;
       auto inputOpDistancePair = opDistanceMap.find(inputOp);
 
       if ((inputOpDistancePair != opDistanceMap.end()) &&

--- a/lib/Conversion/XTenToLinalg.cpp
+++ b/lib/Conversion/XTenToLinalg.cpp
@@ -202,7 +202,8 @@ public:
     auto oper0Ty = operands[0].getType().cast<Torch::BaseTensorType>();
     auto oper1Ty = operands[1].getType().cast<Torch::BaseTensorType>();
     auto dtype = tTy.getDtype();
-    std::vector<int64_t> sizes{oper0Ty.getSizes()[1], oper1Ty.getSizes()[0]};
+    std::vector<int64_t> sizes{oper0Ty.getSizes()[0], oper1Ty.getSizes()[1]};
+
     auto memRefTy = mlir::MemRefType::get(sizes, dtype, {}, 0);
 
     auto A = MemRefTypeCast(rewriter, operands[0]);

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_mm.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_mm.mlir
@@ -9,11 +9,11 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-// CHECK: %[[OUT:.*]] = memref.alloc() : memref<32x32xf32>
-// CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : memref<32x32xf32>, memref<32x32xf32>) outs(%[[OUT]] : memref<32x32xf32>)
+// CHECK: %[[OUT:.*]] = memref.alloc() : memref<1x64xf32>
+// CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : memref<1x32xf32>, memref<32x64xf32>) outs(%[[OUT]] : memref<1x64xf32>)
 module  {
-  func @myFunc(%arg0: !torch.vtensor<[32,32],f32>, %arg1: !torch.vtensor<[32,32],f32>) -> !torch.vtensor<[?,?],f32> {
-    %0 = "xten.mm"(%arg0, %arg1) : (!torch.vtensor<[32,32],f32>, !torch.vtensor<[32,32],f32>) -> !torch.vtensor<[?,?],f32>
-    return %0 : !torch.vtensor<[?,?],f32>
+  func @myFunc(%arg0: !torch.vtensor<[1,32],f32>, %arg1: !torch.vtensor<[32,64],f32>) -> !torch.vtensor<[1,64],f32> {
+    %0 = "xten.mm"(%arg0, %arg1) : (!torch.vtensor<[1,32],f32>, !torch.vtensor<[32,64],f32>) -> !torch.vtensor<[1,64],f32>
+    return %0 : !torch.vtensor<[1,64],f32>
   }
 }


### PR DESCRIPTION
* Correct output shape for `XTenToLinalg`
* Move out redundant lookups for skip-connections