### PR TITLE
Minimal for resnet vizualized

### DIFF
--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -705,15 +705,15 @@ private:
     } else if (auto op2 = dyn_cast<Torch::AtenConstantPadNdOp>(op)) {
       props.appendIntList("Attributes.padding", op2.pad());
     } else if (auto op2 = dyn_cast<Torch::AtenMeanDimOp>(op)) {
-      // props.appendIntList("Attributes.padding", op2.pad());
+      // TODO: fill properties
     } else if (auto op2 = dyn_cast<Torch::AtenSqueezeDimOp>(op)) {
-      // props.appendIntList("Attributes.padding", op2.pad());
+      // TODO: fill properties
     } else if (auto op2 = dyn_cast<Torch::AtenMmOp>(op)) {
-      // props.appendIntList("Attributes.padding", op2.pad());
+      // TODO: fill properties
     } else if (auto op2 = dyn_cast<Torch::Aten_SoftmaxOp>(op)) {
-      // props.appendIntList("Attributes.padding", op2.pad());
+      // TODO: fill properties
     } else if (auto op2 = dyn_cast<Torch::AtenArgmaxOp>(op)) {
-      // props.appendIntList("Attributes.padding", op2.pad());
+      // TODO: fill properties
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dOp>(op)) {
       fillPropertiesConvOp<xten::Conv2dOp>(op2, std::move(props));
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dBatchNormReLUOp>(op)) {
@@ -725,7 +725,7 @@ private:
     } else if (auto op2 = mlir::dyn_cast<xten::AddOp>(op)) {
       // fillPropertiesBinaryALUOp<xten::AddOp>(xtenAddOp, std::move(props));
     } else if (auto op2 = mlir::dyn_cast<xten::MMOp>(op)) {
-      // fillPropertiesBinaryALUOp<xten::MMOp>(xtenAddOp, std::move(props));
+      // TODO: fill properties
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dLReLUPadMaxPoolOp>(op)) {
       // todo pad attributes are missing
       fillPropertiesOpC2dActMaxpool(op2, "aten.lrelu", std::move(props));

--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -704,6 +704,16 @@ private:
       fillPropertiesSliceOp(op2, std::move(props));
     } else if (auto op2 = dyn_cast<Torch::AtenConstantPadNdOp>(op)) {
       props.appendIntList("Attributes.padding", op2.pad());
+    } else if (auto op2 = dyn_cast<Torch::AtenMeanDimOp>(op)) {
+      // props.appendIntList("Attributes.padding", op2.pad());
+    } else if (auto op2 = dyn_cast<Torch::AtenSqueezeDimOp>(op)) {
+      // props.appendIntList("Attributes.padding", op2.pad());
+    } else if (auto op2 = dyn_cast<Torch::AtenMmOp>(op)) {
+      // props.appendIntList("Attributes.padding", op2.pad());
+    } else if (auto op2 = dyn_cast<Torch::Aten_SoftmaxOp>(op)) {
+      // props.appendIntList("Attributes.padding", op2.pad());
+    } else if (auto op2 = dyn_cast<Torch::AtenArgmaxOp>(op)) {
+      // props.appendIntList("Attributes.padding", op2.pad());
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dOp>(op)) {
       fillPropertiesConvOp<xten::Conv2dOp>(op2, std::move(props));
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dBatchNormReLUOp>(op)) {
@@ -714,6 +724,8 @@ private:
       fillPropertiesOpC2dActMaxpool(op2, "aten.lrelu", std::move(props));
     } else if (auto op2 = mlir::dyn_cast<xten::AddOp>(op)) {
       // fillPropertiesBinaryALUOp<xten::AddOp>(xtenAddOp, std::move(props));
+    } else if (auto op2 = mlir::dyn_cast<xten::MMOp>(op)) {
+      // fillPropertiesBinaryALUOp<xten::MMOp>(xtenAddOp, std::move(props));
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dLReLUPadMaxPoolOp>(op)) {
       // todo pad attributes are missing
       fillPropertiesOpC2dActMaxpool(op2, "aten.lrelu", std::move(props));

--- a/lib/Transform/operators_supported.json
+++ b/lib/Transform/operators_supported.json
@@ -28,6 +28,22 @@
 	    ]		
 	},
 	{
+	    "name" : "torch.aten.mean.dim",
+	    "properties" : [
+		["Attributes.dim", "List of dimensions to reduce", "string"],
+		["Attributes.keepdim", "If true, the mean dimensions are kept", "string"],
+		["Computation.Vec Max", "Total number of Vec-Max units in engine", "long"],
+		["Storage.Bytes", "Total storage required for Mean engine", "long"]
+	    ]
+	},
+	{
+	    "name" : "torch.aten.squeeze.dim",
+	    "properties" : [
+		["Attributes.dim", "The dimension of size 1 to remove", "int"],
+		["Storage.Bytes", "Total storage required for Squeeze engine", "long"]
+	    ]
+	},
+	{
 	    "name" : "torch.aten.leaky_relu",
 	    "properties" : [
 		["Attributes.Alpha.Tensor", "Dimensions of alpha", "string"],
@@ -108,6 +124,13 @@
 	    ]
 	},
 	{
+	    "name" : "torch.aten._softmax",
+	    "properties" : [
+		["Attributes.dim", "Value of dimension along which Softmax is computed", "long"],
+		["Storage.Bytes", "Total storage required for Softmax engine", "string"]
+	    ]
+	},
+	{
 	    "name" : "torch.aten.log_softmax",
 	    "properties" : [
 		["Attributes.dim", "Value of dimension along which Softmax is computed", "long"],
@@ -132,12 +155,19 @@
 		["Computation.MACs", "Total number of MAC units in engine", "long"],		
 		["Storage.Bytes", "Total storage required for Linear engine", "string"]	
 	    ]
-	},		
+	},
 	{
 	    "name" : "torch.aten.maximum",
 	    "properties" : [
 		["Computation.Max", "Total number of Max units in engine", "long"],
 		["Storage.Bytes",   "Total storage required for Max engine", "long"]
+	    ]
+	},
+	{
+	    "name" : "torch.aten.mm",
+	    "properties" : [
+		["Computation.*", "Total number of * units in engine", "long"],
+		["Storage.Bytes", "Total storage required for Mul engine", "long"]
 	    ]
 	},
 	{
@@ -436,6 +466,12 @@
 	    "name" : "xten.add",
 	    "properties" : [
 		["Storage.Bytes", "Total storage required for Add engine", "long"]  	 
+	    ]
+	},
+	{
+	    "name" : "xten.mm",
+	    "properties" : [
+		["Storage.Bytes", "Total storage required for matmul engine", "long"]
 	    ]
 	}	
     ]    


### PR DESCRIPTION
I didn't make any attempt to get the table properties filed in properly, but did just enough to have most nodes show up.  
Note it didn't work entirely, as it only shows `softmax` and not `argmax`, but the piecewise improvement is worth having:
![image](https://user-images.githubusercontent.com/25297716/177874345-25c8b47b-c3b1-47b9-812d-7928d1255de7.png)

For reference - netron shows:
![image](https://user-images.githubusercontent.com/25297716/177874600-75bb46f4-8280-40ca-bae3-9c4e16271d8a.png)

