### PR TITLE
FXML-873 Fused op & lowering for Conv2dTensorAdd[[L]ReLU]AveragePool

### DIFF
--- a/include/xten/Conversion/XTenFusions.td
+++ b/include/xten/Conversion/XTenFusions.td
@@ -61,3 +61,13 @@ def : Pat<(Torch_AtenReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)),
 
 def : Pat<(Torch_AtenLeakyReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h), $alpha),
           (XTen_Conv2dTensorAddLReLUOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)>;
+
+// This adds an average pool after the add (+ (leaky) relu)
+def : Pat<(XTen_GlobalAveragePool2D (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)),
+          (XTen_Conv2dTensorAddAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+def : Pat<(XTen_GlobalAveragePool2D (XTen_Conv2dTensorAddReLUOp $a,$b,$c,$d,$e,$f,$g,$h)),
+          (XTen_Conv2dTensorAddReLUAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+
+def : Pat<(XTen_GlobalAveragePool2D (XTen_Conv2dTensorAddLReLUOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)),
+          (XTen_Conv2dTensorAddLReLUAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)>;

--- a/include/xten/Dialect/XTen/XTenOps.td
+++ b/include/xten/Dialect/XTen/XTenOps.td
@@ -607,5 +607,79 @@ def XTen_Conv2dTensorAddLReLUOp: XTen_Op<"conv2d_tensoradd_lrelu", [NoSideEffect
   }];
 }
 
+def XTen_Conv2dTensorAddAveragePoolOp: XTen_Op<"conv2d_tensoradd_averagepool", [NoSideEffect]> {
+  let arguments = (
+    ins AnyTorchTensorType:$input,
+        AnyTorchTensorType:$weight,
+        AnyTorchOptionalTensorType:$bias,
+        Torch_ListType:$stride,
+        Torch_ListType:$padding,
+        Torch_ListType:$dilation,
+        Torch_IntType:$groups,
+
+        AnyTorchTensorType:$add_ifm
+  );
+
+  let results = (
+      outs AnyTorchTensorType:$output
+  );
+
+  let summary = "Convolution with linear activation, then element-wise add with another tensor, then average pool.";
+  let description = [{
+    Convolution with linear activation, then element-wise add with another
+    tensor, then average pool.
+  }];
+}
+
+def XTen_Conv2dTensorAddReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_averagepool", [NoSideEffect]> {
+  let arguments = (
+    ins AnyTorchTensorType:$input,
+        AnyTorchTensorType:$weight,
+        AnyTorchOptionalTensorType:$bias,
+        Torch_ListType:$stride,
+        Torch_ListType:$padding,
+        Torch_ListType:$dilation,
+        Torch_IntType:$groups,
+
+        AnyTorchTensorType:$add_ifm
+  );
+
+  let results = (
+      outs AnyTorchTensorType:$output
+  );
+
+  let summary = "Convolution with linear activation, then element-wise add with another tensor, then ReLU, then average pool.";
+  let description = [{
+    Convolution with linear activation, then element-wise add with another
+    tensor, then ReLU, then average pool.
+  }];
+}
+
+def XTen_Conv2dTensorAddLReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_averagepool", [NoSideEffect]> {
+  let arguments = (
+    ins AnyTorchTensorType:$input,
+        AnyTorchTensorType:$weight,
+        AnyTorchOptionalTensorType:$bias,
+        Torch_ListType:$stride,
+        Torch_ListType:$padding,
+        Torch_ListType:$dilation,
+        Torch_IntType:$groups,
+
+        Torch_FloatType:$alpha, /// for lrelu
+
+        AnyTorchTensorType:$add_ifm
+  );
+
+  let results = (
+      outs AnyTorchTensorType:$output
+  );
+
+  let summary = "Convolution with linear activation, then element-wise add with another tensor, then leaky ReLU, then average pool.";
+  let description = [{
+    Convolution with linear activation, then element-wise add with another
+    tensor, then leaky ReLU, then average pool.
+  }];
+}
+
 
 #endif // #ifndef XTEN_OPS

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -260,6 +260,9 @@ struct ATenToXTenPass : public xten::ATenToXTenBase<ATenToXTenPass> {
     target.addLegalOp<xilinx::xten::Conv2dTensorAddOp>();
     target.addLegalOp<xilinx::xten::Conv2dTensorAddReLUOp>();
     target.addLegalOp<xilinx::xten::Conv2dTensorAddLReLUOp>();
+    target.addLegalOp<xilinx::xten::Conv2dTensorAddAveragePoolOp>();
+    target.addLegalOp<xilinx::xten::Conv2dTensorAddReLUAveragePoolOp>();
+    target.addLegalOp<xilinx::xten::Conv2dTensorAddLReLUAveragePoolOp>();
     target.addLegalOp<xilinx::xten::NoOp>();
     if (failed(applyPatternsAndFoldGreedily(
             module, /*target,*/ std::move(fusionPatterns)))) {

--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -766,6 +766,14 @@ private:
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dReLUPadMaxPoolOp>(op)) {
       // todo pad attributes are missing
       fillPropertiesOpC2dActMaxpool(op2, "aten.relu", std::move(props));
+    } else if (auto op2 = dyn_cast<xten::Conv2dTensorAddAveragePoolOp>(op)) {
+      // TODO: fill properties
+    } else if (auto op2 =
+                   dyn_cast<xten::Conv2dTensorAddReLUAveragePoolOp>(op)) {
+      // TODO: fill properties
+    } else if (auto op2 =
+                   dyn_cast<xten::Conv2dTensorAddLReLUAveragePoolOp>(op)) {
+      // TODO: fill properties
     }
 
     return propertiesArray;

--- a/lib/Transform/operators_supported.json
+++ b/lib/Transform/operators_supported.json
@@ -515,6 +515,18 @@
 	{
 	    "name" : "xten.globalaveragepool2d",
 	    "properties" : []
+	},
+	{
+	    "name" : "xten.conv2d_tensor_add_averagepool",
+	    "properties" : []
+	},
+	{
+	    "name" : "xten.conv2d_tensor_add_relu_averagepool",
+	    "properties" : []
+	},
+	{
+	    "name" : "xten.conv2d_tensor_add_lrelu_averagepool",
+	    "properties" : []
 	}
     ]    
 }

--- a/test/Conversion/ATenToXTen/aten_conv2d_tensoradd_averagepool.mlir
+++ b/test/Conversion/ATenToXTen/aten_conv2d_tensoradd_averagepool.mlir
@@ -1,0 +1,71 @@
+//===- aten_conv2d_tensoradd.mlir ------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Advanced Micro Devices Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aten-opt %s -aten-to-xten -split-input-file | FileCheck %s
+
+
+// CHECK-LABEL:  func @forward_conv2d_tensoradd_lrelu
+// CHECK-SAME:                 %[[INPUT:.*]]: !torch.vtensor<[1,2,128,128],f32>
+// CHECK:   %[[LIST0:.*]] = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:   %[[LIST1:.*]] = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu_averagepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %float4.000000e-01, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+// CHECK-NEXT: return %[[OUT]] : !torch.vtensor<[1,2,1,1],f32>
+func @forward_conv2d_tensoradd_lrelu(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32> {
+  %0 = torch.vtensor.literal(dense<-1.18024689E+29> : tensor<2x2x1x1xf32>) : !torch.vtensor<[2,2,1,1],f32>
+  %none = torch.constant.none
+  %float4.000000e-01 = torch.constant.float 4.000000e-01
+  %int1 = torch.constant.int 1
+  %int0 = torch.constant.int 0
+  %1 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %3 = "xten.conv2d_tensoradd_lrelu"(%arg0, %0, %none, %2, %1, %2, %int1, %float4.000000e-01, %arg0) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
+  %4 = "xten.globalaveragepool2d"(%3) : (!torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+  return %4 : !torch.vtensor<[1,2,1,1],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func @forward_conv2d_tensoradd_relu
+// CHECK-SAME:                 %[[INPUT:.*]]: !torch.vtensor<[1,2,128,128],f32>
+// CHECK:   %[[LIST0:.*]] = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:   %[[LIST1:.*]] = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_relu_averagepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+// CHECK-NEXT: return %[[OUT]] : !torch.vtensor<[1,2,1,1],f32>
+func @forward_conv2d_tensoradd_relu(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32> {
+  %0 = torch.vtensor.literal(dense<-1.18024689E+29> : tensor<2x2x1x1xf32>) : !torch.vtensor<[2,2,1,1],f32>
+  %none = torch.constant.none
+  %int1 = torch.constant.int 1
+  %int0 = torch.constant.int 0
+  %1 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %3 = "xten.conv2d_tensoradd_relu"(%arg0, %0, %none, %2, %1, %2, %int1, %arg0) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
+  %4 = "xten.globalaveragepool2d"(%3) : (!torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+  return %4 : !torch.vtensor<[1,2,1,1],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func @forward_conv2d_tensoradd
+// CHECK-SAME:                 %[[INPUT:.*]]: !torch.vtensor<[1,2,128,128],f32>
+// CHECK:   %[[LIST0:.*]] = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:   %[[LIST1:.*]] = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_averagepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+// CHECK-NEXT: return %[[OUT]] : !torch.vtensor<[1,2,1,1],f32>
+func @forward_conv2d_tensoradd(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32> {
+  %0 = torch.vtensor.literal(dense<-1.18024689E+29> : tensor<2x2x1x1xf32>) : !torch.vtensor<[2,2,1,1],f32>
+  %none = torch.constant.none
+  %int1 = torch.constant.int 1
+  %int0 = torch.constant.int 0
+  %1 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %3 = "xten.conv2d_tensoradd"(%arg0, %0, %none, %2, %1, %2, %int1, %arg0) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
+  %4 = "xten.globalaveragepool2d"(%3) : (!torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+  return %4 : !torch.vtensor<[1,2,1,1],f32>
+}

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_averagepool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_averagepool.mlir
@@ -1,0 +1,30 @@
+//===- xten_to_linalg_conv2d_add.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aten-opt %s -xten-to-linalg | FileCheck %s
+// CHECK: linalg.conv_2d_tensor_add_averagepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+
+module attributes {torch.debug_module_name = "model"} {
+  func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %0 = torch.vtensor.literal(dense<0.0> : tensor<16x2x3x3xf32>) : !torch.vtensor<[16,2,3,3],f32>
+
+    %bias = torch.vtensor.literal(dense<1.0> : tensor<16xf32>) : !torch.vtensor<[16],f32>
+
+    %1 = torch.vtensor.literal(dense<0.0> : tensor<1x2x256x256xf32>) : !torch.vtensor<[1,2,256,256],f32>
+    %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %3 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+    %4 = "xten.conv2d"(%1, %0, %bias, %2, %2, %3, %int1) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,16,128,128],f32>
+    %5 = "xten.conv2d_tensoradd_averagepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
+    
+    return %5 : !torch.vtensor<[1,16,1,1],f32>
+  }
+}

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_lrelu_averagepool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_lrelu_averagepool.mlir
@@ -1,0 +1,31 @@
+//===- xten_to_linalg_conv2d_add_lrelu.mlir --------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aten-opt %s -xten-to-linalg | FileCheck %s
+// CHECK: linalg.conv_2d_tensor_add_lrelu_averagepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+
+module attributes {torch.debug_module_name = "model"} {
+  func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %alpha = torch.constant.float 1.0
+    %0 = torch.vtensor.literal(dense<0.0> : tensor<16x2x3x3xf32>) : !torch.vtensor<[16,2,3,3],f32>
+
+    %bias = torch.vtensor.literal(dense<1.0> : tensor<16xf32>) : !torch.vtensor<[16],f32>
+
+    %1 = torch.vtensor.literal(dense<0.0> : tensor<1x2x256x256xf32>) : !torch.vtensor<[1,2,256,256],f32>
+    %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %3 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+    %4 = "xten.conv2d"(%1, %0, %bias, %2, %2, %3, %int1) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,16,128,128],f32>
+    %5 = "xten.conv2d_tensoradd_lrelu_averagepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %alpha, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
+    
+    return %5 : !torch.vtensor<[1,16,1,1],f32>
+  }
+}

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_relu_averagepool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_relu_averagepool.mlir
@@ -1,0 +1,31 @@
+//===- xten_to_linalg_conv2d_add_relu.mlir ---------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+
+// RUN: aten-opt %s -xten-to-linalg | FileCheck %s
+// CHECK: linalg.conv_2d_tensor_add_relu_averagepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+
+module attributes {torch.debug_module_name = "model"} {
+  func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %0 = torch.vtensor.literal(dense<0.0> : tensor<16x2x3x3xf32>) : !torch.vtensor<[16,2,3,3],f32>
+
+    %bias = torch.vtensor.literal(dense<1.0> : tensor<16xf32>) : !torch.vtensor<[16],f32>
+
+    %1 = torch.vtensor.literal(dense<0.0> : tensor<1x2x256x256xf32>) : !torch.vtensor<[1,2,256,256],f32>
+    %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %3 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+    %4 = "xten.conv2d"(%1, %0, %bias, %2, %2, %3, %int1) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,16,128,128],f32>
+    %5 = "xten.conv2d_tensoradd_relu_averagepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
+    
+    return %5 : !torch.vtensor<[1,16,1,1],f32>
+  }
+}


### PR DESCRIPTION
This PR adds new fused operations to XTen for conv2d_tensoradd_averagepool + relu / leaky relu variants. It also implements the handling in the ATenVisualGraph as well as the lowering to Linalg