### PR TITLE
Fix naming in operators_supported.json for fused Global Average Pool

### DIFF
--- a/include/xten/Conversion/XTenFusions.td
+++ b/include/xten/Conversion/XTenFusions.td
@@ -64,10 +64,10 @@ def : Pat<(Torch_AtenLeakyReluOp (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h
 
 // This adds an average pool after the add (+ (leaky) relu)
 def : Pat<(XTen_GlobalAveragePool2D (XTen_Conv2dTensorAddOp $a,$b,$c,$d,$e,$f,$g,$h)),
-          (XTen_Conv2dTensorAddAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+          (XTen_Conv2dTensorAddGlobalAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$h)>;
 
 def : Pat<(XTen_GlobalAveragePool2D (XTen_Conv2dTensorAddReLUOp $a,$b,$c,$d,$e,$f,$g,$h)),
-          (XTen_Conv2dTensorAddReLUAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$h)>;
+          (XTen_Conv2dTensorAddReLUGlobalAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$h)>;
 
 def : Pat<(XTen_GlobalAveragePool2D (XTen_Conv2dTensorAddLReLUOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)),
-          (XTen_Conv2dTensorAddLReLUAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)>;
+          (XTen_Conv2dTensorAddLReLUGlobalAveragePoolOp $a,$b,$c,$d,$e,$f,$g,$alpha,$h)>;

--- a/include/xten/Dialect/XTen/XTenOps.td
+++ b/include/xten/Dialect/XTen/XTenOps.td
@@ -607,7 +607,7 @@ def XTen_Conv2dTensorAddLReLUOp: XTen_Op<"conv2d_tensoradd_lrelu", [NoSideEffect
   }];
 }
 
-def XTen_Conv2dTensorAddAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalaveragepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalaveragepool", [NoSideEffect]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -631,7 +631,7 @@ def XTen_Conv2dTensorAddAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalaveragepo
   }];
 }
 
-def XTen_Conv2dTensorAddReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_globalaveragepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_globalaveragepool", [NoSideEffect]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -655,7 +655,7 @@ def XTen_Conv2dTensorAddReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_global
   }];
 }
 
-def XTen_Conv2dTensorAddLReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_globalaveragepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddLReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_globalaveragepool", [NoSideEffect]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,

--- a/include/xten/Dialect/XTen/XTenOps.td
+++ b/include/xten/Dialect/XTen/XTenOps.td
@@ -607,7 +607,7 @@ def XTen_Conv2dTensorAddLReLUOp: XTen_Op<"conv2d_tensoradd_lrelu", [NoSideEffect
   }];
 }
 
-def XTen_Conv2dTensorAddAveragePoolOp: XTen_Op<"conv2d_tensoradd_averagepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalaveragepool", [NoSideEffect]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -624,14 +624,14 @@ def XTen_Conv2dTensorAddAveragePoolOp: XTen_Op<"conv2d_tensoradd_averagepool", [
       outs AnyTorchTensorType:$output
   );
 
-  let summary = "Convolution with linear activation, then element-wise add with another tensor, then average pool.";
+  let summary = "Convolution with linear activation, then element-wise add with another tensor, then global average pool.";
   let description = [{
     Convolution with linear activation, then element-wise add with another
     tensor, then average pool.
   }];
 }
 
-def XTen_Conv2dTensorAddReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_averagepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_globalaveragepool", [NoSideEffect]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -648,14 +648,14 @@ def XTen_Conv2dTensorAddReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_averag
       outs AnyTorchTensorType:$output
   );
 
-  let summary = "Convolution with linear activation, then element-wise add with another tensor, then ReLU, then average pool.";
+  let summary = "Convolution with linear activation, then element-wise add with another tensor, then ReLU, then global average pool.";
   let description = [{
     Convolution with linear activation, then element-wise add with another
     tensor, then ReLU, then average pool.
   }];
 }
 
-def XTen_Conv2dTensorAddLReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_averagepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddLReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_globalaveragepool", [NoSideEffect]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -674,7 +674,7 @@ def XTen_Conv2dTensorAddLReLUAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_aver
       outs AnyTorchTensorType:$output
   );
 
-  let summary = "Convolution with linear activation, then element-wise add with another tensor, then leaky ReLU, then average pool.";
+  let summary = "Convolution with linear activation, then element-wise add with another tensor, then leaky ReLU, then global average pool.";
   let description = [{
     Convolution with linear activation, then element-wise add with another
     tensor, then leaky ReLU, then average pool.

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -260,9 +260,9 @@ struct ATenToXTenPass : public xten::ATenToXTenBase<ATenToXTenPass> {
     target.addLegalOp<xilinx::xten::Conv2dTensorAddOp>();
     target.addLegalOp<xilinx::xten::Conv2dTensorAddReLUOp>();
     target.addLegalOp<xilinx::xten::Conv2dTensorAddLReLUOp>();
-    target.addLegalOp<xilinx::xten::Conv2dTensorAddAveragePoolOp>();
-    target.addLegalOp<xilinx::xten::Conv2dTensorAddReLUAveragePoolOp>();
-    target.addLegalOp<xilinx::xten::Conv2dTensorAddLReLUAveragePoolOp>();
+    target.addLegalOp<xilinx::xten::Conv2dTensorAddGlobalAveragePoolOp>();
+    target.addLegalOp<xilinx::xten::Conv2dTensorAddReLUGlobalAveragePoolOp>();
+    target.addLegalOp<xilinx::xten::Conv2dTensorAddLReLUGlobalAveragePoolOp>();
     target.addLegalOp<xilinx::xten::NoOp>();
     if (failed(applyPatternsAndFoldGreedily(
             module, /*target,*/ std::move(fusionPatterns)))) {

--- a/lib/Conversion/XTenToLinalg.cpp
+++ b/lib/Conversion/XTenToLinalg.cpp
@@ -715,16 +715,19 @@ public:
   }
 };
 
-class XTenConv2dTensorAddAveragePoolOpConversion : public ConversionPattern {
+class XTenConv2dTensorAddGlobalAveragePoolOpConversion
+    : public ConversionPattern {
 public:
-  explicit XTenConv2dTensorAddAveragePoolOpConversion(MLIRContext *context)
-      : ConversionPattern(Conv2dTensorAddAveragePoolOp::getOperationName(), 1,
-                          context) {}
+  explicit XTenConv2dTensorAddGlobalAveragePoolOpConversion(
+      MLIRContext *context)
+      : ConversionPattern(
+            Conv2dTensorAddGlobalAveragePoolOp::getOperationName(), 1,
+            context) {}
 
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    auto conv2d = cast<Conv2dTensorAddAveragePoolOp>(op);
+    auto conv2d = cast<Conv2dTensorAddGlobalAveragePoolOp>(op);
     auto loc = conv2d.getLoc();
 
     Value input = ToBuiltinTensorTypeCast(rewriter, operands[0]);
@@ -788,17 +791,19 @@ public:
   }
 };
 
-class XTenConv2dTensorAddReLUAveragePoolOpConversion
+class XTenConv2dTensorAddReLUGlobalAveragePoolOpConversion
     : public ConversionPattern {
 public:
-  explicit XTenConv2dTensorAddReLUAveragePoolOpConversion(MLIRContext *context)
-      : ConversionPattern(Conv2dTensorAddReLUAveragePoolOp::getOperationName(),
-                          1, context) {}
+  explicit XTenConv2dTensorAddReLUGlobalAveragePoolOpConversion(
+      MLIRContext *context)
+      : ConversionPattern(
+            Conv2dTensorAddReLUGlobalAveragePoolOp::getOperationName(), 1,
+            context) {}
 
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    auto conv2dRelu = cast<Conv2dTensorAddReLUAveragePoolOp>(op);
+    auto conv2dRelu = cast<Conv2dTensorAddReLUGlobalAveragePoolOp>(op);
     auto loc = conv2dRelu.getLoc();
 
     Value input = ToBuiltinTensorTypeCast(rewriter, operands[0]);
@@ -862,17 +867,19 @@ public:
   }
 };
 
-class XTenConv2dTensorAddLReLUAveragePoolOpConversion
+class XTenConv2dTensorAddLReLUGlobalAveragePoolOpConversion
     : public ConversionPattern {
 public:
-  explicit XTenConv2dTensorAddLReLUAveragePoolOpConversion(MLIRContext *context)
-      : ConversionPattern(Conv2dTensorAddLReLUAveragePoolOp::getOperationName(),
-                          1, context) {}
+  explicit XTenConv2dTensorAddLReLUGlobalAveragePoolOpConversion(
+      MLIRContext *context)
+      : ConversionPattern(
+            Conv2dTensorAddLReLUGlobalAveragePoolOp::getOperationName(), 1,
+            context) {}
 
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    auto conv2dLRelu = cast<Conv2dTensorAddLReLUAveragePoolOp>(op);
+    auto conv2dLRelu = cast<Conv2dTensorAddLReLUGlobalAveragePoolOp>(op);
     auto loc = conv2dLRelu.getLoc();
 
     Value input = ToBuiltinTensorTypeCast(rewriter, operands[0]);
@@ -1698,25 +1705,19 @@ public:
     // tablegen patterns
     RewritePatternSet patterns(context);
 
-    patterns.insert<XTenAddOpConversion,
-                    XTenMulOpConversion,
-                    XTenMMOpConversion,
-                    XTenConv2dOpConversion,
-                    XTenConv2dReluOpConversion,
-                    XTenConv2dLeakyReluOpConversion,
-                    XTenConv2dLeakyReluMaxPoolOpConversion,
-                    XTenConv2dLeakyReluPadMaxPoolOpConversion,
-                    XTenConv2dReluMaxPoolOpConversion,
-                    XTenConv2dReluPadMaxPoolOpConversion,
-                    XTenPartialConv2dReLUOpConversion,
-                    XTenConv2dTensorAddOpConversion,
-                    XTenConv2dTensorAddReLUOpConversion,
-                    XTenConv2dTensorAddLReLUOpConversion,
-                    XTenSoftmaxOpConversion,
-                    XTenGlobalAveragePool2DOpConversion,
-                    XTenConv2dTensorAddAveragePoolOpConversion,
-                    XTenConv2dTensorAddReLUAveragePoolOpConversion,
-                    XTenConv2dTensorAddLReLUAveragePoolOpConversion>(context);
+    patterns.insert<
+        XTenAddOpConversion, XTenMulOpConversion, XTenMMOpConversion,
+        XTenConv2dOpConversion, XTenConv2dReluOpConversion,
+        XTenConv2dLeakyReluOpConversion, XTenConv2dLeakyReluMaxPoolOpConversion,
+        XTenConv2dLeakyReluPadMaxPoolOpConversion,
+        XTenConv2dReluMaxPoolOpConversion, XTenConv2dReluPadMaxPoolOpConversion,
+        XTenPartialConv2dReLUOpConversion, XTenConv2dTensorAddOpConversion,
+        XTenConv2dTensorAddReLUOpConversion,
+        XTenConv2dTensorAddLReLUOpConversion, XTenSoftmaxOpConversion,
+        XTenGlobalAveragePool2DOpConversion,
+        XTenConv2dTensorAddGlobalAveragePoolOpConversion,
+        XTenConv2dTensorAddReLUGlobalAveragePoolOpConversion,
+        XTenConv2dTensorAddLReLUGlobalAveragePoolOpConversion>(context);
 
     ConversionTarget target(*context);
     

--- a/lib/Conversion/XTenToLinalg.cpp
+++ b/lib/Conversion/XTenToLinalg.cpp
@@ -770,7 +770,7 @@ public:
     // Change appropriate operation over here
     Value conv2dAveragePoolVal =
         rewriter
-            .create<linalg::Conv2dTensorAddAveragePoolOp>(
+            .create<linalg::Conv2dTensorAddGlobalAveragePoolOp>(
                 loc, initTensor.getType(), input, addIfm, weight, bias,
                 initTensor, stridesAttr, dilationAttr)
             .getResult();
@@ -844,7 +844,7 @@ public:
     // Change appropriate operation over here
     Value conv2dReluAveragePoolVal =
         rewriter
-            .create<linalg::Conv2dTensorAddReluAveragePoolOp>(
+            .create<linalg::Conv2dTensorAddReluGlobalAveragePoolOp>(
                 loc, initTensor.getType(), input, addIfm, weight, bias,
                 initTensor, stridesAttr, dilationAttr)
             .getResult();
@@ -927,7 +927,7 @@ public:
     // Change appropriate operation over here
     Value conv2dAddLReluAvgPoolVal =
         rewriter
-            .create<linalg::Conv2dTensorAddLreluAveragePoolOp>(
+            .create<linalg::Conv2dTensorAddLreluGlobalAveragePoolOp>(
                 loc, initTensor.getType(), input, addIfm, weight, bias, alpha,
                 initTensor, stridesAttr, dilationAttr)
             .getResult();

--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -766,13 +766,15 @@ private:
     } else if (auto op2 = mlir::dyn_cast<xten::Conv2dReLUPadMaxPoolOp>(op)) {
       // todo pad attributes are missing
       fillPropertiesOpC2dActMaxpool(op2, "aten.relu", std::move(props));
-    } else if (auto op2 = dyn_cast<xten::Conv2dTensorAddAveragePoolOp>(op)) {
+    } else if (auto op2 =
+                   dyn_cast<xten::Conv2dTensorAddGlobalAveragePoolOp>(op)) {
       // TODO: fill properties
     } else if (auto op2 =
-                   dyn_cast<xten::Conv2dTensorAddReLUAveragePoolOp>(op)) {
+                   dyn_cast<xten::Conv2dTensorAddReLUGlobalAveragePoolOp>(op)) {
       // TODO: fill properties
     } else if (auto op2 =
-                   dyn_cast<xten::Conv2dTensorAddLReLUAveragePoolOp>(op)) {
+                   dyn_cast<xten::Conv2dTensorAddLReLUGlobalAveragePoolOp>(
+                       op)) {
       // TODO: fill properties
     }
 

--- a/lib/Transform/operators_supported.json
+++ b/lib/Transform/operators_supported.json
@@ -517,15 +517,15 @@
 	    "properties" : []
 	},
 	{
-	    "name" : "xten.conv2d_tensor_add_averagepool",
+	    "name" : "xten.conv2d_tensoradd_averagepool",
 	    "properties" : []
 	},
 	{
-	    "name" : "xten.conv2d_tensor_add_relu_averagepool",
+	    "name" : "xten.conv2d_tensoradd_relu_averagepool",
 	    "properties" : []
 	},
 	{
-	    "name" : "xten.conv2d_tensor_add_lrelu_averagepool",
+	    "name" : "xten.conv2d_tensoradd_lrelu_averagepool",
 	    "properties" : []
 	}
     ]    

--- a/lib/Transform/operators_supported.json
+++ b/lib/Transform/operators_supported.json
@@ -517,15 +517,15 @@
 	    "properties" : []
 	},
 	{
-	    "name" : "xten.conv2d_tensoradd_averagepool",
+	    "name" : "xten.conv2d_tensoradd_globalaveragepool",
 	    "properties" : []
 	},
 	{
-	    "name" : "xten.conv2d_tensoradd_relu_averagepool",
+	    "name" : "xten.conv2d_tensoradd_relu_globalaveragepool",
 	    "properties" : []
 	},
 	{
-	    "name" : "xten.conv2d_tensoradd_lrelu_averagepool",
+	    "name" : "xten.conv2d_tensoradd_lrelu_globalaveragepool",
 	    "properties" : []
 	}
     ]    

--- a/test/Conversion/ATenToXTen/aten_conv2d_tensoradd_averagepool.mlir
+++ b/test/Conversion/ATenToXTen/aten_conv2d_tensoradd_averagepool.mlir
@@ -15,7 +15,7 @@
 // CHECK-SAME:                 %[[INPUT:.*]]: !torch.vtensor<[1,2,128,128],f32>
 // CHECK:   %[[LIST0:.*]] = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK:   %[[LIST1:.*]] = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu_averagepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %float4.000000e-01, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu_globalaveragepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %float4.000000e-01, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
 // CHECK-NEXT: return %[[OUT]] : !torch.vtensor<[1,2,1,1],f32>
 func @forward_conv2d_tensoradd_lrelu(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32> {
   %0 = torch.vtensor.literal(dense<-1.18024689E+29> : tensor<2x2x1x1xf32>) : !torch.vtensor<[2,2,1,1],f32>
@@ -36,7 +36,7 @@ func @forward_conv2d_tensoradd_lrelu(%arg0: !torch.vtensor<[1,2,128,128],f32>) -
 // CHECK-SAME:                 %[[INPUT:.*]]: !torch.vtensor<[1,2,128,128],f32>
 // CHECK:   %[[LIST0:.*]] = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK:   %[[LIST1:.*]] = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_relu_averagepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_relu_globalaveragepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
 // CHECK-NEXT: return %[[OUT]] : !torch.vtensor<[1,2,1,1],f32>
 func @forward_conv2d_tensoradd_relu(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32> {
   %0 = torch.vtensor.literal(dense<-1.18024689E+29> : tensor<2x2x1x1xf32>) : !torch.vtensor<[2,2,1,1],f32>
@@ -56,7 +56,7 @@ func @forward_conv2d_tensoradd_relu(%arg0: !torch.vtensor<[1,2,128,128],f32>) ->
 // CHECK-SAME:                 %[[INPUT:.*]]: !torch.vtensor<[1,2,128,128],f32>
 // CHECK:   %[[LIST0:.*]] = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK:   %[[LIST1:.*]] = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_averagepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
+// CHECK:   %[[OUT:.*]] = "xten.conv2d_tensoradd_globalaveragepool"(%[[INPUT]], %0, %none, %[[LIST1]], %[[LIST0]], %[[LIST1]], %int1, %[[INPUT]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32>
 // CHECK-NEXT: return %[[OUT]] : !torch.vtensor<[1,2,1,1],f32>
 func @forward_conv2d_tensoradd(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,1,1],f32> {
   %0 = torch.vtensor.literal(dense<-1.18024689E+29> : tensor<2x2x1x1xf32>) : !torch.vtensor<[2,2,1,1],f32>

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_averagepool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_averagepool.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-// CHECK: linalg.conv_2d_tensor_add_averagepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+// CHECK: linalg.conv_2d_tensor_add_globalaveragepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
 
 module attributes {torch.debug_module_name = "model"} {
   func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32> {
@@ -23,7 +23,7 @@ module attributes {torch.debug_module_name = "model"} {
     %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
     %3 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
     %4 = "xten.conv2d"(%1, %0, %bias, %2, %2, %3, %int1) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,16,128,128],f32>
-    %5 = "xten.conv2d_tensoradd_averagepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
+    %5 = "xten.conv2d_tensoradd_globalaveragepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
     
     return %5 : !torch.vtensor<[1,16,1,1],f32>
   }

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_lrelu_averagepool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_lrelu_averagepool.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-// CHECK: linalg.conv_2d_tensor_add_lrelu_averagepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+// CHECK: linalg.conv_2d_tensor_add_lrelu_globalaveragepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
 
 module attributes {torch.debug_module_name = "model"} {
   func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32> {
@@ -24,7 +24,7 @@ module attributes {torch.debug_module_name = "model"} {
     %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
     %3 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
     %4 = "xten.conv2d"(%1, %0, %bias, %2, %2, %3, %int1) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,16,128,128],f32>
-    %5 = "xten.conv2d_tensoradd_lrelu_averagepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %alpha, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
+    %5 = "xten.conv2d_tensoradd_lrelu_globalaveragepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %alpha, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
     
     return %5 : !torch.vtensor<[1,16,1,1],f32>
   }

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_relu_averagepool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_add_relu_averagepool.mlir
@@ -10,7 +10,7 @@
 
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-// CHECK: linalg.conv_2d_tensor_add_relu_averagepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+// CHECK: linalg.conv_2d_tensor_add_relu_globalaveragepool {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x2x130x130xf32>, tensor<1x16x128x128xf32>, tensor<16x2x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
 
 module attributes {torch.debug_module_name = "model"} {
   func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32> {
@@ -24,7 +24,7 @@ module attributes {torch.debug_module_name = "model"} {
     %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
     %3 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
     %4 = "xten.conv2d"(%1, %0, %bias, %2, %2, %3, %int1) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,16,128,128],f32>
-    %5 = "xten.conv2d_tensoradd_relu_averagepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
+    %5 = "xten.conv2d_tensoradd_relu_globalaveragepool"(%arg0, %0, %bias, %2, %2, %2, %int1, %4) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[16,2,3,3],f32>, !torch.vtensor<[16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,16,128,128],f32>) -> !torch.vtensor<[1,16,1,1],f32>
     
     return %5 : !torch.vtensor<[1,16,1,1],f32>
   }


### PR DESCRIPTION
Fixed the naming in the supported operators and renamed classes/functions to reflect that they are concerned with the fused global average pool.