### PR TITLE
fuse conv2d with smallest IFM to add (from cfa087f9b3584ddfa)

### DIFF
--- a/include/xten/Conversion/XTenFusions.td
+++ b/include/xten/Conversion/XTenFusions.td
@@ -31,7 +31,7 @@ include "xten/Dialect/XTen/XTenOps.td"
 
 
 def SelectFirstC2dInSymmetricTensorAdd : Constraint<
-    CPred<"isLongestBranch($0, $1)">,
+    CPred<"fuseFirstC2dInTensorAdd($0, $1)">,
     "fuse first parameter into tensor add, otherwise fuse second.">;
 
 // This pattern catches the case where 2 conv2ds are inputs to an add.

--- a/test/Conversion/ATenToXTen/aten_double_conv2d_add.mlir
+++ b/test/Conversion/ATenToXTen/aten_double_conv2d_add.mlir
@@ -14,8 +14,8 @@
 // CHECK: %[[INT2:.*]] = torch.constant.int 2
 // CHECK: %[[INT1L:.*]] = torch.prim.ListConstruct %[[INT1]], %[[INT1]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK: %[[INT2L:.*]] = torch.prim.ListConstruct %[[INT2]], %[[INT2]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK: %[[C2D:.*]] = "xten.conv2d"(%[[IN1:.*]], %{{[^,]*}}, %none, %[[INT1L]], %[[INT1L]], %[[INT1L]], %[[INT1]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,2,128,128],f32>
-// CHECK: %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu"(%[[IN2:.*]], %{{[^,]*}}, %none, %[[INT2L]], %[[INT1L]], %[[INT1L]], %[[INT1]], %float4.000000e-01, %[[C2D]]) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
+// CHECK: %[[C2D:.*]] = "xten.conv2d"(%[[IN1:.*]], %{{[^,]*}}, %none, %[[INT2L]], %[[INT1L]], %[[INT1L]], %[[INT1]]) : (!torch.vtensor<[1,2,256,256],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,2,128,128],f32>
+// CHECK: %[[OUT:.*]] = "xten.conv2d_tensoradd_lrelu"(%[[IN2:.*]], %{{[^,]*}}, %none, %[[INT1L]], %[[INT1L]], %[[INT1L]], %[[INT1]], %float4.000000e-01, %[[C2D]]) : (!torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.float, !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32>
 
 module attributes {torch.debug_module_name = "model"}  {
   func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32> {

--- a/test/Conversion/ATenToXTen/aten_long_conv2d_add.mlir
+++ b/test/Conversion/ATenToXTen/aten_long_conv2d_add.mlir
@@ -1,0 +1,39 @@
+//===- aten_long_conv2d_add.mlir -------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aten-opt %s -aten-to-xten | FileCheck %s
+
+// Verify that the conv2d with the longest path to a common ancestor is fused
+// with the subsequent add.
+//
+// CHECK: %[[COMMON:.*]] = "xten.add"(%arg0, %arg1
+// CHECK: %[[C2D1:.*]] = "xten.conv2d"(%[[COMMON]]
+// CHECK: %[[C2D1a:.*]] = "xten.conv2d"(%[[COMMON]]
+// CHECK: %[[OUT:.*]] = "xten.conv2d_tensoradd_relu"(%[[C2D1]]
+// CHECK-SAME: %[[C2D1a]])
+
+module attributes {torch.debug_module_name = "model"}  {
+  func @forward(%arg0: !torch.vtensor<[1,2,128,128],f32>, %arg1: !torch.vtensor<[1,2,128,128],f32>) -> !torch.vtensor<[1,2,128,128],f32> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %weight = torch.vtensor.literal(dense<"0xDEADBEEF"> : tensor<2x2x3x3xf32>) : !torch.vtensor<[2,2,3,3],f32>
+    %none = torch.constant.none
+    %int1List = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %stride2 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+
+    %common = torch.aten.add.Tensor %arg0, %arg1, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[1,2,128,128],f32>, !torch.int ->  !torch.vtensor<[1,2,128,128],f32>
+    %c2d1 = torch.aten.conv2d %common, %weight, %none, %int1List, %int1List, %int1List, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+    %c2d1a = torch.aten.conv2d %common, %weight, %none, %int1List, %int1List, %int1List, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+    %c2d2 = torch.aten.conv2d %c2d1, %weight, %none, %int1List, %int1List, %int1List, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,128,128],f32>
+    %7 = torch.aten.add.Tensor %c2d2, %c2d1a, %int1 : !torch.vtensor<[1,2,128,128],f32>, !torch.vtensor<[1,2,128,128],f32>, !torch.int ->  !torch.vtensor<[1,2,128,128],f32>
+    %8 = torch.aten.relu %7 : !torch.vtensor<[1,2,128,128],f32> -> !torch.vtensor<[1,2,128,128],f32>
+    return %8 : !torch.vtensor<[1,2,128,128],f32>
+  }
+}


### PR DESCRIPTION
When an add has both inputs from conv2d ops, the heuristic to decide which to merge is adapted to select the one with the smallest IFM. Only if it cannot be determined that one IFM is smaller is the longest path heuristic applied.