### PR TITLE
Lexically schedule to reduce feature-map memory requirements

### DIFF
--- a/include/xten/Transform/Passes.h
+++ b/include/xten/Transform/Passes.h
@@ -15,13 +15,10 @@
 #include "xten/Transform/ATenLoweringPass.h"
 #include "xten/Transform/ATenVisualGraph.h"
 #include "xten/Transform/LowerToLibATenPass.h"
+#include "xten/Transform/XTenMinimizeLiveTensors.h"
 
-namespace xilinx {
-namespace xten {
-
+namespace xilinx::xten {
 void registerTransformPasses();
-
-} // namespace xten
-} // namespace xilinx
+} // namespace xilinx::xten
 
 #endif // XTEN_TRANSFORM_PASSES_H

--- a/include/xten/Transform/Passes.td
+++ b/include/xten/Transform/Passes.td
@@ -5,11 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // (c) Copyright 2021 Xilinx Inc.
+// (c) Copyright 2022 Advanced Micro Devices, Inc.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ATEN_CONVERSION_PASSES
-#define ATEN_CONVERSION_PASSES
+#ifndef ATEN_TRANSFORM_PASSES
+#define ATEN_TRANSFORM_PASSES
 
 include "mlir/Pass/PassBase.td"
 
@@ -33,5 +34,9 @@ def LowerToLibATen : Pass<"lower-to-libaten", "ModuleOp"> {
   let constructor = "xilinx::xten::createLowerToLibATenPass()";
 }
 
+def XTenMinimizeLiveTensors : Pass<"xten-minimize-live", "func::FuncOp"> {
+  let summary = "reorder xten operations to minimize the total size of the live tensors";
+  let constructor = "xilinx::xten::createXTenMinimizeLiveTensorsPass()";
+}
 
-#endif // ATEN_CONVERSION_PASSES
+#endif // ATEN_TRANSFORM_PASSES

--- a/include/xten/Transform/XTenMinimizeLiveTensors.h
+++ b/include/xten/Transform/XTenMinimizeLiveTensors.h
@@ -1,0 +1,25 @@
+//===- XTenMinimizeLiveTensors.h -------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef XTenMinimizeLiveTensors_PASS_H
+#define XTenMinimizeLiveTensors_PASS_H
+
+#include <memory>
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::func {
+class FuncOp;
+} // namespace mlir::func
+
+namespace xilinx::xten {
+std::unique_ptr<mlir::OperationPass<mlir::func::FuncOp>> createXTenMinimizeLiveTensorsPass();
+} // namespace xilinx::xten
+
+#endif // XTenMinimizeLiveTensors_PASS_H

--- a/lib/Transform/CMakeLists.txt
+++ b/lib/Transform/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_library(XTenTransformPasses
   ATenVisualGraph.cpp
   LowerToLibATenPass.cpp
   Passes.cpp
+  XTenMinimizeLiveTensors.cpp
 
   DEPENDS
   MLIRXTenOpsIncGen

--- a/lib/Transform/PassDetail.h
+++ b/lib/Transform/PassDetail.h
@@ -11,6 +11,7 @@
 #ifndef XTEN_TRANSFORM_PASSDETAIL_H
 #define XTEN_TRANSFORM_PASSDETAIL_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 

--- a/lib/Transform/XTenMinimizeLiveTensors.cpp
+++ b/lib/Transform/XTenMinimizeLiveTensors.cpp
@@ -1,0 +1,361 @@
+//===- XTenMinimizeLiveTensors.cpp -----------------------------------*- C++
+//-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// This pass reorders operations to minimize the total size of live feature map
+// tensors.
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
+#include "xten/Dialect/XTen/XTenDialect.h"
+#include "xten/Dialect/XTen/XTenOps.h"
+#include "xten/Util/Util.h"
+#include <memory>
+#include <set>
+
+#define DEBUG_TYPE "xten-minimize-live"
+
+using namespace mlir;
+using namespace xilinx::xten;
+
+namespace {
+
+/// FM tensor sizes for a single operation.
+struct OpSizes {
+  /// Total size of the FM operands.
+  size_t operands;
+  /// Total size of the FM results.
+  size_t results;
+  /// Total size needed when executing, allowing for memory sharing.
+  size_t running;
+};
+
+/// Information about memory requirements if the ops on a dependence
+/// branch are executed.
+/// Note that ops with with multiple predecessors decide the order
+/// of predecessor execution before they are added to the running
+/// information, so once available it should be correct.
+struct BranchRunning {
+  /// The max size needed to run any operation on this branch.
+  size_t maxRunning = 0;
+  /// The size of the results of the last op in this branch.
+  size_t lastResults = 0;
+  /// The last op in this branch.
+  Operation *lastOp;
+};
+
+/// Various analysis results about an operation.
+struct OpInfo {
+  /// The operand this node represents.
+  Operation *const op;
+  /// The feature map operand values of this node.
+  SmallVector<Value> const operands;
+  /// The feature map results this node.
+  SmallVector<Value> const results;
+  /// The value that will share memory with the result during execution, if any.
+  Optional<Value> const sharesResultMemory = {};
+  /// The consumers of any results. Note: this is filled progressively while
+  /// collecting the operations.
+  SmallVector<Operation *> consumers;
+  /// Cumulative sizes of the FM tensors.
+  OpSizes sizes = {};
+  /// The preferred order of producers of the operands. Note: this is filled
+  /// by post-analysis of the branching information.
+  SmallVector<Operation *> orderedProducers;
+  /// True when the operation has been moved in the IR.
+  bool ordered = false;
+};
+
+/// HARDCODED returns the operand that will share memory with the result.
+bool isConvAddChained(Operation *op) {
+  if (isa<xilinx::xten::Conv2dTensorAddOp>(op))
+    return true;
+  if (isa<xilinx::xten::Conv2dTensorAddReLUOp>(op))
+    return true;
+  if (isa<xilinx::xten::Conv2dTensorAddLReLUOp>(op))
+    return true;
+  if (isa<xilinx::xten::Conv2dTensorAddGlobalAveragePoolOp>(op))
+    return true;
+  if (isa<xilinx::xten::Conv2dTensorAddReLUGlobalAveragePoolOp>(op))
+    return true;
+  if (isa<xilinx::xten::Conv2dTensorAddLReLUGlobalAveragePoolOp>(op))
+    return true;
+
+  return false;
+}
+
+/// HARDCODED returns the operand that will share memory with the result.
+Optional<Value> sharesMemoryWithResult(Operation *op) {
+  if (isConvAddChained(op))
+    return {op->getOperands().back()};
+
+  return {};
+}
+
+/// HARDCODED returns all FM operands.
+SmallVector<Value> getFmOperands(Operation *op) {
+  // No input to the function.
+  if (isa<func::FuncOp>(op))
+    return {};
+
+  // not sure of the syntax to unpack operand 0 - skip for now.
+  assert(!isa<xilinx::xten::ConcatOp>(op));
+
+  // Per operand defined IFMs.
+  if (isa<xilinx::xten::AddOp>(op))
+    return op->getOperands();
+  if (isa<xilinx::xten::MulOp>(op))
+    return op->getOperands();
+  if (isa<xilinx::xten::MMOp>(op))
+    return op->getOperands();
+  if (isConvAddChained(op))
+    return {op->getOperands().front(), op->getOperands().back()};
+
+  // TODO: there is no guarantee that FM is only the 1st operand. It
+  // would be better to check all ops, preferably via an interface.
+  // Okay for prototype, knowing this may backfire in debug effort.
+  return {op->getOperand(0)};
+}
+
+/// Return the size of the tensor type of \p val.
+/// It is an error to call this with a non-tensor typed value.
+size_t getSize(Value val) {
+  assert(val.getType().isa<torch::Torch::BaseTensorType>());
+  return xilinx::xten::getTensorVolume(val.getType());
+}
+
+/// Debugging support - returns a simple name for an op.
+StringRef getName(Operation *op) {
+  if (op->hasAttr("layer_name"))
+    return op->getAttrOfType<StringAttr>("layer_name").getValue();
+  return op->getName().getStringRef();
+}
+
+/// Debugging support - returns a string with all the op names.
+std::string toStr(SmallVector<Operation *> const &vec) {
+  std::string str("(");
+  for (auto *op : vec)
+    str += std::string(::getName(op)) + " ";
+  return str + ")";
+}
+
+/// Determine the in/out/running L2 memory needed per Fwd.
+void setOpSizes(OpInfo &opInfo) {
+  size_t outgoing = 0;
+  for_each(opInfo.results,
+            [&outgoing](Value val) { outgoing += getSize(val); });
+  opInfo.sizes.results = outgoing;
+  size_t incoming = 0;
+  for_each(opInfo.operands,
+            [&incoming](Value val) { incoming += getSize(val); });
+  opInfo.sizes.operands = incoming;
+  opInfo.sizes.running = incoming;
+  if (!opInfo.sharesResultMemory)
+    opInfo.sizes.running += outgoing;
+}
+
+class XTenMinimizeLiveTensorsPass
+    : public XTenMinimizeLiveTensorsBase<XTenMinimizeLiveTensorsPass> {
+public:
+  XTenMinimizeLiveTensorsPass() = default;
+  XTenMinimizeLiveTensorsPass(const XTenMinimizeLiveTensorsPass &pass) =
+      default;
+
+  // Recursively collect the OpInfo of all FM producers.
+  void collectOperandInfo(OpInfo const &opInfo) { // NOLINT(misc-no-recursion)
+    // Visit all FM operands to collect their OpInfo.
+    for (auto operand : opInfo.operands) {
+      Operation *defOp = operand.getDefiningOp();
+      if (defOp == nullptr) {
+        // Use currFn as stand-in for BlockArguments.
+        assert(operand.isa<BlockArgument>());
+        defOp = currFn;
+      }
+
+      // If OpInfo is already created, so we only need to note this consumer.
+      auto prevInfoIt = opToInfo.find(defOp);
+      if (prevInfoIt != opToInfo.end()) {
+        prevInfoIt->second.consumers.push_back(opInfo.op);
+        continue;
+      }
+
+      // Create the new OpInfo for the operand.
+      SmallVector<Value> const fmOperands = getFmOperands(defOp);
+      SmallVector<Value> fmResults;
+      if (defOp != currFn) {
+        fmResults = defOp->getResults();
+      } else {
+        fmResults = SmallVector<Value>(currFn.getBody().front().getArguments());
+      }
+      Optional<Value> const sharesResultMemory = sharesMemoryWithResult(defOp);
+      OpInfo info = {.op = defOp,
+                     .operands = fmOperands,
+                     .results = fmResults,
+                     .sharesResultMemory = sharesResultMemory,
+                     .consumers = {opInfo.op}};
+      auto [opFwdIt, succeeded] = opToInfo.emplace(defOp, std::move(info));
+      setOpSizes(opFwdIt->second);
+      // Recursively collect details of the operands of this operand.
+      collectOperandInfo(opFwdIt->second);
+    }
+  }
+
+  /// Recursively determine branch running sizes.
+  ///
+  /// \p opInfo points to the info for the op being analyzed.
+  /// \p brInfo incoming branch info, to be updated by this op.
+  /// \p completed contains the BranchRunning info for any fully
+  ///    analyzed operations.
+  void determineBranchRunning(OpInfo *opInfo, // NOLINT(misc-no-recursion)
+                              BranchRunning &brInfo,
+                              std::map<Operation *, BranchRunning> &completed) {
+    // Analyze simple fallthrough operations.
+    while (opInfo->operands.size() < 2 && opInfo->consumers.size() < 2) {
+      brInfo.maxRunning = std::max(brInfo.maxRunning, opInfo->sizes.results);
+      brInfo.lastResults = opInfo->sizes.results;
+      opInfo->orderedProducers = {brInfo.lastOp};
+      brInfo.lastOp = opInfo->op;
+      completed.insert({opInfo->op, brInfo});
+
+      if (opInfo->consumers.empty())
+        return; // Nothing more to compute.
+      opInfo = &opToInfo.at(opInfo->consumers.front());
+    }
+
+      // At a joining point - collect this branch and proceed iff all incoming
+      // branches have been collected.
+    SmallVector<BranchRunning> branches;
+      for (Value val : opInfo->operands) {
+        Operation *op = val.getDefiningOp();
+        if (op == nullptr)
+          op = currFn; // BlockArgument stand-in.
+
+        auto opIt = completed.find(op);
+        if (opIt == completed.end())
+          return; // Another producer needs to complete first.
+      branches.push_back(opIt->second);
+      }
+
+    std::sort(branches.begin(), branches.end(),
+              [](BranchRunning &aBranch, BranchRunning &bBranch) -> bool {
+                return (aBranch.maxRunning - aBranch.lastResults) >
+                       (bBranch.maxRunning - bBranch.lastResults);
+                });
+      opInfo->orderedProducers.clear();
+    for (BranchRunning const &branch : branches)
+        opInfo->orderedProducers.push_back(branch.lastOp);
+
+    // Complete the brInfo for this operation.
+    size_t maxRunning = opInfo->sizes.running;
+    for (BranchRunning const &branch : branches)
+      maxRunning = std::max(maxRunning, branch.maxRunning);
+    brInfo.maxRunning = maxRunning;
+    brInfo.lastResults = opInfo->sizes.results;
+    brInfo.lastOp = opInfo->op;
+    completed.insert({opInfo->op, brInfo});
+
+    // Continue to all consumers.
+    for (Operation *consumer : opInfo->consumers) {
+      BranchRunning nextRunning{.maxRunning = maxRunning,
+                                .lastResults = opInfo->sizes.results,
+                                .lastOp = opInfo->op};
+      determineBranchRunning(&opToInfo.at(consumer), nextRunning, completed);
+    }
+    assert(opInfo->orderedProducers.size() == opInfo->operands.size());
+  }
+
+  /// Move the operators to the desired lexical order.
+  void moveToOrder(OpInfo const &fwd) { // NOLINT(misc-no-recursion)
+    for (Operation *op : fwd.orderedProducers) {
+      if (op == currFn)
+        continue; // BlockArguments cannot be moved.
+      OpInfo &visitFwd = opToInfo.at(op);
+      if (visitFwd.ordered)
+        continue;
+
+      op->moveBefore(fwd.op);
+      visitFwd.ordered = true;
+      moveToOrder(visitFwd);
+    }
+  }
+
+  void runOnOperation() override {
+    auto fwdFn = getOperation();
+    mlir::Region &body = fwdFn.getBody();
+    if (!body.hasOneBlock()) {
+      fwdFn.emitError("function has complex control flow, aborting");
+      signalPassFailure();
+      return;
+    }
+    currFn = fwdFn;
+
+    // A single block is expected. Building the initial graph starts from the
+    // return and is successful when all FMs are ultimately produced from the
+    // function arguments.
+    Operation *returnStmt = body.begin()->getTerminator();
+    assert(isa<func::ReturnOp>(returnStmt) &&
+           "A function must terminate with a return stmt");
+    SmallVector<Value> const retVal = returnStmt->getOperands();
+    OpInfo fwdInfo = {.op = returnStmt, .operands = retVal, .results = {}};
+    auto [opFwdIt, succeeded] =
+        opToInfo.emplace(returnStmt, std::move(fwdInfo));
+    OpInfo const &retFwd = opFwdIt->second;
+
+    collectOperandInfo(retFwd);
+
+    auto prevFwdIt = opToInfo.find(currFn);
+    if (prevFwdIt == opToInfo.end()) {
+      returnStmt->emitError(
+          "function entry is not reached from the return stmt");
+      signalPassFailure();
+      return;
+    }
+    OpInfo &fnFwd = prevFwdIt->second;
+    BranchRunning nextRunning{.maxRunning = fnFwd.sizes.running,
+                              .lastResults = fnFwd.sizes.results,
+                              .lastOp = fnFwd.op};
+    std::map<Operation *, BranchRunning> completed;
+    determineBranchRunning(&fnFwd, nextRunning, completed);
+
+    // print();
+
+    moveToOrder(retFwd);
+  }
+
+private:
+  /// The analysis results for each operation.
+  std::map<Operation *, OpInfo> opToInfo;
+  /// The function being analyzed - needed in places to represent
+  /// BlockArguments.
+  mlir::func::FuncOp currFn;
+
+  /// Debugging support - print some details of all .
+  void print() {
+    for (auto &[op, info] : opToInfo) {
+      llvm::errs() << ::getName(op)
+                   << " producers: " << toStr(info.orderedProducers)
+                   << " consumers: " << toStr(info.consumers) << "\n";
+    }
+    llvm::errs() << "----\n";
+  }
+};
+
+} // namespace
+
+namespace xilinx::xten {
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createXTenMinimizeLiveTensorsPass() {
+  return std::make_unique<XTenMinimizeLiveTensorsPass>();
+}
+
+} // namespace xilinx::xten

--- a/test/Transform/XTenMinimizeLiveTensors/diamonds.mlir
+++ b/test/Transform/XTenMinimizeLiveTensors/diamonds.mlir
@@ -1,0 +1,172 @@
+// RUN: aten-opt %s -xten-minimize-live -split-input-file | FileCheck %s
+
+// A diamond shaped dependency graph, where the order is expected to change.
+// CHECK-LABEL:     one_diamond
+// CHECK:     "conv2d_relu0"
+// CHECK:     "conv2d_relu1"
+// CHECK:     "conv2d0"
+// CHECK:     "conv2d_tensoradd_relu0"
+
+func.func @one_diamond(%31: !torch.vtensor<[1,64,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.vtensor.literal(dense<0.00999999977> : tensor<64xf32>) : !torch.vtensor<[64],f32>
+  %2 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x1x1xf32>) : !torch.vtensor<[64,64,1,1],f32>
+  %3 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x3x3xf32>) : !torch.vtensor<[64,64,3,3],f32>
+  %4 = torch.vtensor.literal(dense<2.000000e-02> : tensor<256x64x1x1xf32>) : !torch.vtensor<[256,64,1,1],f32>
+  %5 = torch.vtensor.literal(dense<0.00999999977> : tensor<256xf32>) : !torch.vtensor<[256],f32>
+  %29 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %32 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+
+  %33 = "xten.conv2d"(%31, %4, %5, %29, %32, %29, %int1) {layer_name = "conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %34 = "xten.conv2d_relu"(%31, %2, %1, %29, %32, %29, %int1) {layer_name = "conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %35 = "xten.conv2d_relu"(%34, %3, %1, %29, %29, %29, %int1) {layer_name = "conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %36 = "xten.conv2d_tensoradd_relu"(%35, %4, %5, %29, %32, %29, %int1, %33) {layer_name = "conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+  return %36 : !torch.vtensor<[1,256,56,56],f32>
+}
+
+// -----
+
+// Same as one_diamond, but the order is already as expected.
+// CHECK-LABEL:     one_rev_diamond
+// CHECK:     "conv2d_relu0"
+// CHECK:     "conv2d_relu1"
+// CHECK:     "conv2d0"
+// CHECK:     "conv2d_tensoradd_relu0"
+
+func.func @one_rev_diamond(%31: !torch.vtensor<[1,64,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.vtensor.literal(dense<0.00999999977> : tensor<64xf32>) : !torch.vtensor<[64],f32>
+  %2 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x1x1xf32>) : !torch.vtensor<[64,64,1,1],f32>
+  %3 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x3x3xf32>) : !torch.vtensor<[64,64,3,3],f32>
+  %4 = torch.vtensor.literal(dense<2.000000e-02> : tensor<256x64x1x1xf32>) : !torch.vtensor<[256,64,1,1],f32>
+  %5 = torch.vtensor.literal(dense<0.00999999977> : tensor<256xf32>) : !torch.vtensor<[256],f32>
+  %29 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %32 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+
+  %34 = "xten.conv2d_relu"(%31, %2, %1, %29, %32, %29, %int1) {layer_name = "conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %35 = "xten.conv2d_relu"(%34, %3, %1, %29, %29, %29, %int1) {layer_name = "conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %33 = "xten.conv2d"(%31, %4, %5, %29, %32, %29, %int1) {layer_name = "conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %36 = "xten.conv2d_tensoradd_relu"(%35, %4, %5, %29, %32, %29, %int1, %33) {layer_name = "conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+  return %36 : !torch.vtensor<[1,256,56,56],f32>
+}
+
+// -----
+
+// Check that the sort is stable for two identical diamonds
+// CHECK-LABEL:     double_identical_diamond
+// CHECK:     "a_conv2d_relu0"
+// CHECK:     "a_conv2d_relu1"
+// CHECK:     "a_conv2d0"
+// CHECK:     "a_conv2d_tensoradd_relu0"
+// CHECK:     "b_conv2d_relu0"
+// CHECK:     "b_conv2d_relu1"
+// CHECK:     "b_conv2d0"
+// CHECK:     "b_conv2d_tensoradd_relu0"
+// CHECK:     "add0"
+
+func.func @double_identical_diamond(%a31: !torch.vtensor<[1,64,56,56],f32>, %b31: !torch.vtensor<[1,64,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.vtensor.literal(dense<0.00999999977> : tensor<64xf32>) : !torch.vtensor<[64],f32>
+  %2 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x1x1xf32>) : !torch.vtensor<[64,64,1,1],f32>
+  %3 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x3x3xf32>) : !torch.vtensor<[64,64,3,3],f32>
+  %4 = torch.vtensor.literal(dense<2.000000e-02> : tensor<256x64x1x1xf32>) : !torch.vtensor<[256,64,1,1],f32>
+  %5 = torch.vtensor.literal(dense<0.00999999977> : tensor<256xf32>) : !torch.vtensor<[256],f32>
+  %29 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %32 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+
+  %a34 = "xten.conv2d_relu"(%a31, %2, %1, %29, %32, %29, %int1) {layer_name = "a_conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %a35 = "xten.conv2d_relu"(%a34, %3, %1, %29, %29, %29, %int1) {layer_name = "a_conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %a33 = "xten.conv2d"(%a31, %4, %5, %29, %32, %29, %int1) {layer_name = "a_conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %a36 = "xten.conv2d_tensoradd_relu"(%a35, %4, %5, %29, %32, %29, %int1, %a33) {layer_name = "a_conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+
+  %b34 = "xten.conv2d_relu"(%b31, %2, %1, %29, %32, %29, %int1) {layer_name = "b_conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %b35 = "xten.conv2d_relu"(%b34, %3, %1, %29, %29, %29, %int1) {layer_name = "b_conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %b33 = "xten.conv2d"(%b31, %4, %5, %29, %32, %29, %int1) {layer_name = "b_conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %b36 = "xten.conv2d_tensoradd_relu"(%b35, %4, %5, %29, %32, %29, %int1, %b33) {layer_name = "b_conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+
+  %36 = "xten.add"(%a36, %b36) {layer_name = "add0"} : (!torch.vtensor<[1,256,56,56],f32>, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+  return %36 : !torch.vtensor<[1,256,56,56],f32>
+}
+
+// -----
+
+// Check that the sort is stable for two identical diamonds
+// CHECK-LABEL:     swap_double_identical_diamond
+// CHECK:     "b_conv2d_relu0"
+// CHECK:     "b_conv2d_relu1"
+// CHECK:     "b_conv2d0"
+// CHECK:     "b_conv2d_tensoradd_relu0"
+// CHECK:     "a_conv2d_relu0"
+// CHECK:     "a_conv2d_relu1"
+// CHECK:     "a_conv2d0"
+// CHECK:     "a_conv2d_tensoradd_relu0"
+// CHECK:     "add0"
+
+func.func @swap_double_identical_diamond(%a31: !torch.vtensor<[1,64,56,56],f32>, %b31: !torch.vtensor<[1,64,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.vtensor.literal(dense<0.00999999977> : tensor<64xf32>) : !torch.vtensor<[64],f32>
+  %2 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x1x1xf32>) : !torch.vtensor<[64,64,1,1],f32>
+  %3 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x3x3xf32>) : !torch.vtensor<[64,64,3,3],f32>
+  %4 = torch.vtensor.literal(dense<2.000000e-02> : tensor<256x64x1x1xf32>) : !torch.vtensor<[256,64,1,1],f32>
+  %5 = torch.vtensor.literal(dense<0.00999999977> : tensor<256xf32>) : !torch.vtensor<[256],f32>
+  %29 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %32 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+
+  %b34 = "xten.conv2d_relu"(%b31, %2, %1, %29, %32, %29, %int1) {layer_name = "b_conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %b35 = "xten.conv2d_relu"(%b34, %3, %1, %29, %29, %29, %int1) {layer_name = "b_conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %b33 = "xten.conv2d"(%b31, %4, %5, %29, %32, %29, %int1) {layer_name = "b_conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %b36 = "xten.conv2d_tensoradd_relu"(%b35, %4, %5, %29, %32, %29, %int1, %b33) {layer_name = "b_conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+
+  %a34 = "xten.conv2d_relu"(%a31, %2, %1, %29, %32, %29, %int1) {layer_name = "a_conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %a35 = "xten.conv2d_relu"(%a34, %3, %1, %29, %29, %29, %int1) {layer_name = "a_conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %a33 = "xten.conv2d"(%a31, %4, %5, %29, %32, %29, %int1) {layer_name = "a_conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %a36 = "xten.conv2d_tensoradd_relu"(%a35, %4, %5, %29, %32, %29, %int1, %a33) {layer_name = "a_conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+
+  %36 = "xten.add"(%b36, %a36) {layer_name = "add0"} : (!torch.vtensor<[1,256,56,56],f32>, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+  return %36 : !torch.vtensor<[1,256,56,56],f32>
+}
+
+// -----
+
+// Two diamond shaped dependency graph, where the order is expected to change.
+// CHECK-LABEL:     two_diamond
+// CHECK:     "conv2d_relu0"
+// CHECK:     "conv2d_relu1"
+// CHECK:     "conv2d0"
+// CHECK:     "conv2d_tensoradd_relu0"
+// CHECK:     "conv2d_relu2"
+// CHECK:     "conv2d_relu3"
+// CHECK:     "conv2d1"
+// CHECK:     "conv2d_tensoradd_relu1"
+
+func.func @two_diamond(%31: !torch.vtensor<[1,64,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.vtensor.literal(dense<0.00999999977> : tensor<64xf32>) : !torch.vtensor<[64],f32>
+  %2 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x1x1xf32>) : !torch.vtensor<[64,64,1,1],f32>
+  %3 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x64x3x3xf32>) : !torch.vtensor<[64,64,3,3],f32>
+  %4 = torch.vtensor.literal(dense<2.000000e-02> : tensor<256x64x1x1xf32>) : !torch.vtensor<[256,64,1,1],f32>
+  %5 = torch.vtensor.literal(dense<0.00999999977> : tensor<256xf32>) : !torch.vtensor<[256],f32>
+  %6 = torch.vtensor.literal(dense<2.000000e-02> : tensor<64x256x1x1xf32>) : !torch.vtensor<[64,256,1,1],f32>
+  %29 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %32 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+
+  %33 = "xten.conv2d"(%31, %4, %5, %29, %32, %29, %int1) {layer_name = "conv2d0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %34 = "xten.conv2d_relu"(%31, %2, %1, %29, %32, %29, %int1) {layer_name = "conv2d_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %35 = "xten.conv2d_relu"(%34, %3, %1, %29, %29, %29, %int1) {layer_name = "conv2d_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %36 = "xten.conv2d_tensoradd_relu"(%35, %4, %5, %29, %32, %29, %int1, %33) {layer_name = "conv2d_tensoradd_relu0"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+
+  %x15 = torch.vtensor.literal(dense<2.000000e-02> : tensor<256x256x1x1xf32>) : !torch.vtensor<[256,256,1,1],f32>
+  %x33 = "xten.conv2d"(%36, %x15, %5, %29, %32, %29, %int1) {layer_name = "conv2d1"} : (!torch.vtensor<[1,256,56,56],f32>, !torch.vtensor<[256,256,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,256,56,56],f32>
+  %37 = "xten.conv2d_relu"(%36, %6, %1, %29, %32, %29, %int1) {layer_name = "conv2d_relu2"} : (!torch.vtensor<[1,256,56,56],f32>, !torch.vtensor<[64,256,1,1],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %38 = "xten.conv2d_relu"(%37, %3, %1, %29, %29, %29, %int1) {layer_name = "conv2d_relu3"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[64,64,3,3],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.vtensor<[1,64,56,56],f32>
+  %39 = "xten.conv2d_tensoradd_relu"(%38, %4, %5, %29, %32, %29, %int1, %x33) {layer_name = "conv2d_tensoradd_relu1"} : (!torch.vtensor<[1,64,56,56],f32>, !torch.vtensor<[256,64,1,1],f32>, !torch.vtensor<[256],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,56,56],f32>
+
+
+  return %39 : !torch.vtensor<[1,256,56,56],f32>
+}
+


### PR DESCRIPTION
This pass re-orders the XTen operations to reduce the total size of the live tensors when executing sequentially.

- [x] add tests