### PR TITLE
Bump to LLVM green commit 4546397e39589f0a6a707218349d1bf65fe54645 from Oct. 17

### DIFF
--- a/include/xten/Dialect/XTen/XTenDataflowUtils.h
+++ b/include/xten/Dialect/XTen/XTenDataflowUtils.h
@@ -17,7 +17,7 @@
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 
 using namespace mlir;

--- a/include/xten/Dialect/XTen/XTenOps.h
+++ b/include/xten/Dialect/XTen/XTenOps.h
@@ -20,6 +20,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 
 #define GET_OP_CLASSES
 #include "xten/Dialect/XTen/XTenOps.h.inc"

--- a/include/xten/Dialect/XTen/XTenOps.td
+++ b/include/xten/Dialect/XTen/XTenOps.td
@@ -50,7 +50,7 @@ def XTen_AddOp: XTen_Op<"add", []>,
   }];
 }
 
-def XTen_MMOp: XTen_Op<"mm", [NoSideEffect]>,
+def XTen_MMOp: XTen_Op<"mm", [Pure]>,
               Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins AnyTorchTensorType:$x,
@@ -91,7 +91,7 @@ def XTen_SoftmaxOp: XTen_Op<"softmax", []>,
   }];
 }
 
-def XTen_GlobalAveragePool2D: XTen_Op<"globalaveragepool2d", [NoSideEffect]>,
+def XTen_GlobalAveragePool2D: XTen_Op<"globalaveragepool2d", [Pure]>,
                Results<(outs AnyTorchTensorType:$output)> {
   let arguments = (
     ins AnyTorchTensorType:$input
@@ -116,7 +116,7 @@ def XTen_NoOp: XTen_Op<"noop", []>,
   }];
 }
 
-def XTen_Conv2dOp: XTen_Op<"conv2d", [NoSideEffect]>,
+def XTen_Conv2dOp: XTen_Op<"conv2d", [Pure]>,
                                 Results<(outs AnyTorchTensorType:$result)> {
   let arguments = (
     ins AnyTorchTensorType:$input,
@@ -140,7 +140,7 @@ def XTen_Conv2dOp: XTen_Op<"conv2d", [NoSideEffect]>,
 }
 
 // TODO what happens when we have both?
-def XTen_PartialConv2dOp: XTen_Op<"partialconv2d", [NoSideEffect]>{
+def XTen_PartialConv2dOp: XTen_Op<"partialconv2d", [Pure]>{
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchOptionalTensorType:$PartialIn,
@@ -169,7 +169,7 @@ def XTen_PartialConv2dOp: XTen_Op<"partialconv2d", [NoSideEffect]>{
 }
 
 
-def XTen_Conv2dReLUOp: XTen_Op<"conv2d_relu", [NoSideEffect]>,
+def XTen_Conv2dReLUOp: XTen_Op<"conv2d_relu", [Pure]>,
                                    Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins AnyTorchTensorType:$input,
@@ -193,7 +193,7 @@ def XTen_Conv2dReLUOp: XTen_Op<"conv2d_relu", [NoSideEffect]>,
 }
 
 def XTen_PartialConv2dReLUOp: XTen_Op<"partialconv2d_relu",
-                                [NoSideEffect]> {
+                                [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchOptionalTensorType:$PartialIn,
@@ -221,7 +221,7 @@ def XTen_PartialConv2dReLUOp: XTen_Op<"partialconv2d_relu",
 	}];
 }
 
-def XTen_Conv2dBatchNormReLUOp: XTen_Op<"conv2d_bn_relu", [NoSideEffect]>,
+def XTen_Conv2dBatchNormReLUOp: XTen_Op<"conv2d_bn_relu", [Pure]>,
                                             Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins AnyTorchTensorType:$input,
@@ -253,7 +253,7 @@ def XTen_Conv2dBatchNormReLUOp: XTen_Op<"conv2d_bn_relu", [NoSideEffect]>,
 }
 
 def XTen_PartialConv2dBatchNormReLUOp: XTen_Op<"partialconv2d_bn_relu",
-                                        [NoSideEffect]> {
+                                        [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchOptionalTensorType:$PartialIn,
@@ -288,7 +288,7 @@ def XTen_PartialConv2dBatchNormReLUOp: XTen_Op<"partialconv2d_bn_relu",
 	}];
 }
 
-def XTen_ConcatOp: XTen_Op<"concat", [NoSideEffect]>,
+def XTen_ConcatOp: XTen_Op<"concat", [Pure]>,
                                 Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins Variadic<AnyTorchTensorType>:$inputs,
@@ -307,7 +307,7 @@ def XTen_ConcatOp: XTen_Op<"concat", [NoSideEffect]>,
 }
 
 // TODO Proper verifier for this operation?
-def XTen_SplitOp: XTen_Op<"split", [NoSideEffect]> {
+def XTen_SplitOp: XTen_Op<"split", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         XTen_AnyScalar:$dim
@@ -328,7 +328,7 @@ def XTen_SplitOp: XTen_Op<"split", [NoSideEffect]> {
 	}];
 }
 
-def XTen_Conv2dLReLUOp: XTen_Op<"conv2d_lrelu", [NoSideEffect]>,
+def XTen_Conv2dLReLUOp: XTen_Op<"conv2d_lrelu", [Pure]>,
                                    Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins AnyTorchTensorType:$input,
@@ -352,7 +352,7 @@ def XTen_Conv2dLReLUOp: XTen_Op<"conv2d_lrelu", [NoSideEffect]>,
 	}];
 }
 
-def XTen_Conv2dLReLUPadOp: XTen_Op<"conv2d_lrelu_pad", [NoSideEffect]>,
+def XTen_Conv2dLReLUPadOp: XTen_Op<"conv2d_lrelu_pad", [Pure]>,
                                    Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins AnyTorchTensorType:$input,
@@ -379,7 +379,7 @@ def XTen_Conv2dLReLUPadOp: XTen_Op<"conv2d_lrelu_pad", [NoSideEffect]>,
 }
 
 
-def XTen_Conv2dReLUPadOp: XTen_Op<"conv2d_relu_pad", [NoSideEffect]>,
+def XTen_Conv2dReLUPadOp: XTen_Op<"conv2d_relu_pad", [Pure]>,
                                    Results<(outs AnyTorchTensorType)> {
   let arguments = (
     ins AnyTorchTensorType:$input,
@@ -405,7 +405,7 @@ def XTen_Conv2dReLUPadOp: XTen_Op<"conv2d_relu_pad", [NoSideEffect]>,
 }
 
 
-def XTen_Conv2dReLUMaxPoolOp: XTen_Op<"conv2d_relu_maxpool", [NoSideEffect]> {
+def XTen_Conv2dReLUMaxPoolOp: XTen_Op<"conv2d_relu_maxpool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -436,7 +436,7 @@ def XTen_Conv2dReLUMaxPoolOp: XTen_Op<"conv2d_relu_maxpool", [NoSideEffect]> {
 	}];
 }
 
-def XTen_Conv2dReLUPadMaxPoolOp: XTen_Op<"conv2d_relu_pad_maxpool", [NoSideEffect]> {
+def XTen_Conv2dReLUPadMaxPoolOp: XTen_Op<"conv2d_relu_pad_maxpool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -470,7 +470,7 @@ def XTen_Conv2dReLUPadMaxPoolOp: XTen_Op<"conv2d_relu_pad_maxpool", [NoSideEffec
 }
 
 
-def XTen_Conv2dLReLUMaxPoolOp: XTen_Op<"conv2d_lrelu_maxpool", [NoSideEffect]> {
+def XTen_Conv2dLReLUMaxPoolOp: XTen_Op<"conv2d_lrelu_maxpool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -502,7 +502,7 @@ def XTen_Conv2dLReLUMaxPoolOp: XTen_Op<"conv2d_lrelu_maxpool", [NoSideEffect]> {
 	}];
 }
 
-def XTen_Conv2dLReLUPadMaxPoolOp: XTen_Op<"conv2d_lrelu_pad_maxpool", [NoSideEffect]> {
+def XTen_Conv2dLReLUPadMaxPoolOp: XTen_Op<"conv2d_lrelu_pad_maxpool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -536,7 +536,7 @@ def XTen_Conv2dLReLUPadMaxPoolOp: XTen_Op<"conv2d_lrelu_pad_maxpool", [NoSideEff
 	}];
 }
 
-def XTen_Conv2dTensorAddOp: XTen_Op<"conv2d_tensoradd", [NoSideEffect]> {
+def XTen_Conv2dTensorAddOp: XTen_Op<"conv2d_tensoradd", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -559,7 +559,7 @@ def XTen_Conv2dTensorAddOp: XTen_Op<"conv2d_tensoradd", [NoSideEffect]> {
   }];
 }
 
-def XTen_Conv2dTensorAddReLUOp: XTen_Op<"conv2d_tensoradd_relu", [NoSideEffect]> {
+def XTen_Conv2dTensorAddReLUOp: XTen_Op<"conv2d_tensoradd_relu", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -582,7 +582,7 @@ def XTen_Conv2dTensorAddReLUOp: XTen_Op<"conv2d_tensoradd_relu", [NoSideEffect]>
   }];
 }
 
-def XTen_Conv2dTensorAddLReLUOp: XTen_Op<"conv2d_tensoradd_lrelu", [NoSideEffect]> {
+def XTen_Conv2dTensorAddLReLUOp: XTen_Op<"conv2d_tensoradd_lrelu", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -607,7 +607,7 @@ def XTen_Conv2dTensorAddLReLUOp: XTen_Op<"conv2d_tensoradd_lrelu", [NoSideEffect
   }];
 }
 
-def XTen_Conv2dTensorAddGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalaveragepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalaveragepool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -631,7 +631,7 @@ def XTen_Conv2dTensorAddGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_globalave
   }];
 }
 
-def XTen_Conv2dTensorAddReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_globalaveragepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_globalaveragepool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -655,7 +655,7 @@ def XTen_Conv2dTensorAddReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_relu_
   }];
 }
 
-def XTen_Conv2dTensorAddLReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_globalaveragepool", [NoSideEffect]> {
+def XTen_Conv2dTensorAddLReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrelu_globalaveragepool", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,
@@ -681,7 +681,7 @@ def XTen_Conv2dTensorAddLReLUGlobalAveragePoolOp: XTen_Op<"conv2d_tensoradd_lrel
   }];
 }
 
-def XTen_LinearOp: XTen_Op<"linear", [NoSideEffect]> {
+def XTen_LinearOp: XTen_Op<"linear", [Pure]> {
   let arguments = (
     ins AnyTorchTensorType:$input,
         AnyTorchTensorType:$weight,

--- a/lib/Conversion/ATenToXTenPass.cpp
+++ b/lib/Conversion/ATenToXTenPass.cpp
@@ -156,7 +156,7 @@ long getSize(TensorType &t) {
 
 // Returns the IFM size of the conv2d.
 long getInputSize(xten::Conv2dOp &c2d) {
-  TensorType inputType = c2d.input()
+  TensorType inputType = c2d.getInput()
                              .getType()
                              .dyn_cast<Torch::ValueTensorType>()
                              .toBuiltinTensor();

--- a/lib/Conversion/XTenToLinalg.cpp
+++ b/lib/Conversion/XTenToLinalg.cpp
@@ -140,7 +140,7 @@ static LogicalResult processConv2d(T &conv2dOp, Location &loc, Value &input,
 
   SmallVector<int64_t> paddingInts;
   paddingInts.resize(2, 0);
-  if (!matchPattern(conv2dOp.padding(),
+  if (!matchPattern(conv2dOp.getPadding(),
                     Torch::m_TorchConstantIntList(paddingInts))) {
     return rewriter.notifyMatchFailure(op,
                                        "only support constant padding values");
@@ -151,7 +151,7 @@ static LogicalResult processConv2d(T &conv2dOp, Location &loc, Value &input,
   input = applyPad(loc, input, paddingInts, zeroAttr, rewriter);
 
   int64_t groups;
-  if (!matchPattern(conv2dOp.groups(), Torch::m_TorchConstantInt(&groups)))
+  if (!matchPattern(conv2dOp.getGroups(), Torch::m_TorchConstantInt(&groups)))
     return rewriter.notifyMatchFailure(op, "only support constant int group");
 
   if (groups != 1)
@@ -304,7 +304,7 @@ public:
 
     Value input = ToBuiltinTensorTypeCast(rewriter, operands[0]);
     Value weight = ToBuiltinTensorTypeCast(rewriter, operands[1]);
-    Value biasInitTensor = getBiasedInit(op, conv2d.bias(), loc, rewriter);
+    Value biasInitTensor = getBiasedInit(op, conv2d.getBias(), loc, rewriter);
 
     Type elementType =
         input.getType().cast<RankedTensorType>().getElementType();
@@ -313,7 +313,7 @@ public:
 
     SmallVector<int64_t> paddingInts;
     paddingInts.resize(2, 0);
-    if (!matchPattern(conv2d.padding(),
+    if (!matchPattern(conv2d.getPadding(),
                       Torch::m_TorchConstantIntList(paddingInts))) {
       return rewriter.notifyMatchFailure(
           op, "only support constant padding values");
@@ -324,19 +324,19 @@ public:
     input = applyPad(loc, input, paddingInts, zeroAttr, rewriter);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2d.stride(),
+    if (!matchPattern(conv2d.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2d.dilation(),
+    if (!matchPattern(conv2d.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 
     int64_t groups;
-    if (!matchPattern(conv2d.groups(), Torch::m_TorchConstantInt(&groups)))
+    if (!matchPattern(conv2d.getGroups(), Torch::m_TorchConstantInt(&groups)))
       return rewriter.notifyMatchFailure(op, "only support constant int group");
 
     if (groups != 1)
@@ -386,13 +386,13 @@ public:
       return result;
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dRelu.stride(),
+    if (!matchPattern(conv2dRelu.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dRelu.dilation(),
+    if (!matchPattern(conv2dRelu.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -458,13 +458,13 @@ public:
     Value alpha = rewriter.create<arith::ConstantOp>(loc, ty, add_const);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dLRelu.stride(),
+    if (!matchPattern(conv2dLRelu.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dLRelu.dilation(),
+    if (!matchPattern(conv2dLRelu.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -521,13 +521,13 @@ public:
       return result;
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2d.stride(),
+    if (!matchPattern(conv2d.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2d.dilation(),
+    if (!matchPattern(conv2d.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -591,13 +591,13 @@ public:
       return result;
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dRelu.stride(),
+    if (!matchPattern(conv2dRelu.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dRelu.dilation(),
+    if (!matchPattern(conv2dRelu.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -670,13 +670,13 @@ public:
     Value alpha = rewriter.create<arith::ConstantOp>(loc, ty, add_const);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dLRelu.stride(),
+    if (!matchPattern(conv2dLRelu.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dLRelu.dilation(),
+    if (!matchPattern(conv2dLRelu.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -743,13 +743,13 @@ public:
       return result;
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2d.stride(),
+    if (!matchPattern(conv2d.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2d.dilation(),
+    if (!matchPattern(conv2d.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -815,13 +815,13 @@ public:
       return result;
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dRelu.stride(),
+    if (!matchPattern(conv2dRelu.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dRelu.dilation(),
+    if (!matchPattern(conv2dRelu.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -896,13 +896,13 @@ public:
     Value alpha = rewriter.create<arith::ConstantOp>(loc, ty, addCst);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dLRelu.stride(),
+    if (!matchPattern(conv2dLRelu.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dLRelu.dilation(),
+    if (!matchPattern(conv2dLRelu.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
@@ -966,7 +966,7 @@ public:
 
     SmallVector<int64_t> paddingInts;
     paddingInts.resize(2, 0);
-    if (!matchPattern(conv2dLReluMaxpool.padding(),
+    if (!matchPattern(conv2dLReluMaxpool.getPadding(),
                       Torch::m_TorchConstantIntList(paddingInts))) {
       return rewriter.notifyMatchFailure(
           op, "only support constant padding values");
@@ -983,48 +983,48 @@ public:
     input = applyPad(loc, input, paddingInts, zeroAttr, rewriter);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dLReluMaxpool.stride(),
+    if (!matchPattern(conv2dLReluMaxpool.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dLReluMaxpool.dilation(),
+    if (!matchPattern(conv2dLReluMaxpool.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 
     SmallVector<int64_t, 2> mp_kernel_sizeInts;
-    if (!matchPattern(conv2dLReluMaxpool.mp_kernel_size(),
+    if (!matchPattern(conv2dLReluMaxpool.getMpKernelSize(),
                       Torch::m_TorchConstantIntList(mp_kernel_sizeInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_kernel_size");
 
     SmallVector<int64_t, 2> mp_strideInts;
-    if (!matchPattern(conv2dLReluMaxpool.mp_stride(),
+    if (!matchPattern(conv2dLReluMaxpool.getMpStride(),
                       Torch::m_TorchConstantIntList(mp_strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int mp_stride");
 
     SmallVector<int64_t, 2> mp_paddingInts;
-    if (!matchPattern(conv2dLReluMaxpool.mp_padding(),
+    if (!matchPattern(conv2dLReluMaxpool.getMpPadding(),
                       Torch::m_TorchConstantIntList(mp_paddingInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_padding");
 
     SmallVector<int64_t, 2> mp_dilationInts;
-    if (!matchPattern(conv2dLReluMaxpool.mp_dilation(),
+    if (!matchPattern(conv2dLReluMaxpool.getMpDilation(),
                       Torch::m_TorchConstantIntList(mp_dilationInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_dilation");
 
     int64_t groups;
-    if (!matchPattern(conv2dLReluMaxpool.groups(),
+    if (!matchPattern(conv2dLReluMaxpool.getGroups(),
                       Torch::m_TorchConstantInt(&groups)))
       return rewriter.notifyMatchFailure(op, "only support constant int group");
 
     bool mp_ceil_mode;
-    if (!matchPattern(conv2dLReluMaxpool.mp_ceil_mode(),
+    if (!matchPattern(conv2dLReluMaxpool.getMpCeilMode(),
                       Torch::m_TorchConstantBool(&mp_ceil_mode)))
       return rewriter.notifyMatchFailure(op,
                                          "only support bool type mp_ceil_mode");
@@ -1117,7 +1117,7 @@ public:
 
     SmallVector<int64_t> paddingInts;
     paddingInts.resize(2, 0);
-    if (!matchPattern(conv2dLReluPadMaxpool.padding(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getPadding(),
                       Torch::m_TorchConstantIntList(paddingInts))) {
       return rewriter.notifyMatchFailure(
           op, "only support constant padding values");
@@ -1134,54 +1134,54 @@ public:
     input = applyPad(loc, input, paddingInts, zeroAttr, rewriter);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dLReluPadMaxpool.stride(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dLReluPadMaxpool.dilation(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 
     SmallVector<int64_t> pad_paddingInts; // Wl, Wh, Hl, Hh
-    if (!matchPattern(conv2dLReluPadMaxpool.pad_padding(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getPadPadding(),
                       Torch::m_TorchConstantIntList(pad_paddingInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int pad_padding");
 
     SmallVector<int64_t, 2> mp_kernel_sizeInts;
-    if (!matchPattern(conv2dLReluPadMaxpool.mp_kernel_size(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getMpKernelSize(),
                       Torch::m_TorchConstantIntList(mp_kernel_sizeInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_kernel_size");
 
     SmallVector<int64_t, 2> mp_strideInts;
-    if (!matchPattern(conv2dLReluPadMaxpool.mp_stride(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getMpStride(),
                       Torch::m_TorchConstantIntList(mp_strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int mp_stride");
 
     SmallVector<int64_t> mp_paddingInts; // H, W
-    if (!matchPattern(conv2dLReluPadMaxpool.mp_padding(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getMpPadding(),
                       Torch::m_TorchConstantIntList(mp_paddingInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_padding");
 
     SmallVector<int64_t, 2> mp_dilationInts;
-    if (!matchPattern(conv2dLReluPadMaxpool.mp_dilation(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getMpDilation(),
                       Torch::m_TorchConstantIntList(mp_dilationInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_dilation");
 
     int64_t groups;
-    if (!matchPattern(conv2dLReluPadMaxpool.groups(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getGroups(),
                       Torch::m_TorchConstantInt(&groups)))
       return rewriter.notifyMatchFailure(op, "only support constant int group");
 
     bool mp_ceil_mode;
-    if (!matchPattern(conv2dLReluPadMaxpool.mp_ceil_mode(),
+    if (!matchPattern(conv2dLReluPadMaxpool.getMpCeilMode(),
                       Torch::m_TorchConstantBool(&mp_ceil_mode)))
       return rewriter.notifyMatchFailure(op,
                                          "only support bool type mp_ceil_mode");
@@ -1278,7 +1278,7 @@ public:
 
     SmallVector<int64_t> paddingInts;
     paddingInts.resize(2, 0);
-    if (!matchPattern(conv2dReluMaxpool.padding(),
+    if (!matchPattern(conv2dReluMaxpool.getPadding(),
                       Torch::m_TorchConstantIntList(paddingInts))) {
       return rewriter.notifyMatchFailure(
           op, "only support constant padding values");
@@ -1289,48 +1289,48 @@ public:
     input = applyPad(loc, input, paddingInts, zeroAttr, rewriter);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dReluMaxpool.stride(),
+    if (!matchPattern(conv2dReluMaxpool.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dReluMaxpool.dilation(),
+    if (!matchPattern(conv2dReluMaxpool.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 
     SmallVector<int64_t, 2> mp_kernel_sizeInts;
-    if (!matchPattern(conv2dReluMaxpool.mp_kernel_size(),
+    if (!matchPattern(conv2dReluMaxpool.getMpKernelSize(),
                       Torch::m_TorchConstantIntList(mp_kernel_sizeInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_kernel_size");
 
     SmallVector<int64_t, 2> mp_strideInts;
-    if (!matchPattern(conv2dReluMaxpool.mp_stride(),
+    if (!matchPattern(conv2dReluMaxpool.getMpStride(),
                       Torch::m_TorchConstantIntList(mp_strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int mp_stride");
 
     SmallVector<int64_t, 2> mp_paddingInts;
-    if (!matchPattern(conv2dReluMaxpool.mp_padding(),
+    if (!matchPattern(conv2dReluMaxpool.getMpPadding(),
                       Torch::m_TorchConstantIntList(mp_paddingInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_padding");
 
     SmallVector<int64_t, 2> mp_dilationInts;
-    if (!matchPattern(conv2dReluMaxpool.mp_dilation(),
+    if (!matchPattern(conv2dReluMaxpool.getMpDilation(),
                       Torch::m_TorchConstantIntList(mp_dilationInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_dilation");
 
     int64_t groups;
-    if (!matchPattern(conv2dReluMaxpool.groups(),
+    if (!matchPattern(conv2dReluMaxpool.getGroups(),
                       Torch::m_TorchConstantInt(&groups)))
       return rewriter.notifyMatchFailure(op, "only support constant int group");
 
     bool mp_ceil_mode;
-    if (!matchPattern(conv2dReluMaxpool.mp_ceil_mode(),
+    if (!matchPattern(conv2dReluMaxpool.getMpCeilMode(),
                       Torch::m_TorchConstantBool(&mp_ceil_mode)))
       return rewriter.notifyMatchFailure(op,
                                          "only support bool type mp_ceil_mode");
@@ -1419,7 +1419,7 @@ public:
 
     SmallVector<int64_t> paddingInts;
     paddingInts.resize(2, 0);
-    if (!matchPattern(conv2dReluPadMaxpool.padding(),
+    if (!matchPattern(conv2dReluPadMaxpool.getPadding(),
                       Torch::m_TorchConstantIntList(paddingInts))) {
       return rewriter.notifyMatchFailure(
           op, "only support constant padding values");
@@ -1430,54 +1430,54 @@ public:
     input = applyPad(loc, input, paddingInts, zeroAttr, rewriter);
 
     SmallVector<int64_t, 2> strideInts;
-    if (!matchPattern(conv2dReluPadMaxpool.stride(),
+    if (!matchPattern(conv2dReluPadMaxpool.getStride(),
                       Torch::m_TorchConstantIntList(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
 
     SmallVector<int64_t, 2> dilationInts;
-    if (!matchPattern(conv2dReluPadMaxpool.dilation(),
+    if (!matchPattern(conv2dReluPadMaxpool.getDilation(),
                       Torch::m_TorchConstantIntList(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 
     SmallVector<int64_t> pad_paddingInts; // Wl, Wh, Hl, Hh
-    if (!matchPattern(conv2dReluPadMaxpool.pad_padding(),
+    if (!matchPattern(conv2dReluPadMaxpool.getPadPadding(),
                       Torch::m_TorchConstantIntList(pad_paddingInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int pad_padding");
 
     SmallVector<int64_t, 2> mp_kernel_sizeInts;
-    if (!matchPattern(conv2dReluPadMaxpool.mp_kernel_size(),
+    if (!matchPattern(conv2dReluPadMaxpool.getMpKernelSize(),
                       Torch::m_TorchConstantIntList(mp_kernel_sizeInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_kernel_size");
 
     SmallVector<int64_t, 2> mp_strideInts;
-    if (!matchPattern(conv2dReluPadMaxpool.mp_stride(),
+    if (!matchPattern(conv2dReluPadMaxpool.getMpStride(),
                       Torch::m_TorchConstantIntList(mp_strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int mp_stride");
 
     SmallVector<int64_t> mp_paddingInts; // H, W
-    if (!matchPattern(conv2dReluPadMaxpool.mp_padding(),
+    if (!matchPattern(conv2dReluPadMaxpool.getMpPadding(),
                       Torch::m_TorchConstantIntList(mp_paddingInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_padding");
 
     SmallVector<int64_t, 2> mp_dilationInts;
-    if (!matchPattern(conv2dReluPadMaxpool.mp_dilation(),
+    if (!matchPattern(conv2dReluPadMaxpool.getMpDilation(),
                       Torch::m_TorchConstantIntList(mp_dilationInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int mp_dilation");
 
     int64_t groups;
-    if (!matchPattern(conv2dReluPadMaxpool.groups(),
+    if (!matchPattern(conv2dReluPadMaxpool.getGroups(),
                       Torch::m_TorchConstantInt(&groups)))
       return rewriter.notifyMatchFailure(op, "only support constant int group");
 
     bool mp_ceil_mode;
-    if (!matchPattern(conv2dReluPadMaxpool.mp_ceil_mode(),
+    if (!matchPattern(conv2dReluPadMaxpool.getMpCeilMode(),
                       Torch::m_TorchConstantBool(&mp_ceil_mode)))
       return rewriter.notifyMatchFailure(op,
                                          "only support bool type mp_ceil_mode");
@@ -1679,9 +1679,9 @@ public:
 
     // Cast the input arguments to default tensor type and convert bias
     // to an empty tensor if not given.
-    Value input = ToBuiltinTensorTypeCast(rewriter, op.input());
-    Value weights = ToBuiltinTensorTypeCast(rewriter, op.weight());
-    Value bias = convertBias(op, op.bias(), loc, rewriter);
+    Value input = ToBuiltinTensorTypeCast(rewriter, op.getInput());
+    Value weights = ToBuiltinTensorTypeCast(rewriter, op.getWeight());
+    Value bias = convertBias(op, op.getBias(), loc, rewriter);
 
     // Create the linalg version of linear
     auto torchResultType =

--- a/lib/Conversion/XTenToLinalg.cpp
+++ b/lib/Conversion/XTenToLinalg.cpp
@@ -74,7 +74,7 @@ static Value applyPad(Location loc, Value input, ArrayRef<int64_t> pad,
 static Value zeroInit(ArrayRef<int64_t> sizes, mlir::Type elementType,
                       Location loc, ConversionPatternRewriter &rewriter) {
   Value initTensor =
-      rewriter.create<linalg::InitTensorOp>(loc, sizes, elementType);
+      rewriter.create<tensor::EmptyOp>(loc, sizes, elementType);
   Value c0float = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getZeroAttr(elementType));
   return rewriter.create<linalg::FillOp>(loc, c0float, initTensor).getResult(0);
@@ -100,7 +100,7 @@ static Value getBiasedInit(Operation *op, Value atenBias, Location loc,
       op->getResult(0).getType().dyn_cast<torch::Torch::BaseTensorType>();
   assert(outputTy);
   auto elementType = outputTy.getDtype();
-  Value initTensor = rewriter.create<linalg::InitTensorOp>(
+  Value initTensor = rewriter.create<tensor::EmptyOp>(
       loc, outputTy.getSizes(), elementType);
 
   if (atenBias.getType().isa<Torch::NoneType>()) {
@@ -190,7 +190,7 @@ public:
     auto elementTy = tensorTy.getDtype();
     auto sizes = tensorTy.getSizes();
     auto rank = sizes.size();
-    Value C = rewriter.create<linalg::InitTensorOp>(loc, sizes, elementTy);
+    Value C = rewriter.create<tensor::EmptyOp>(loc, sizes, elementTy);
 
     SmallVector<Value, 2> inputTensors{A, B};
     SmallVector<Value, 1> outputTensors{C};
@@ -407,7 +407,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     Value conv2dReluVal =
@@ -479,7 +479,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     Value conv2dLReluVal = rewriter
@@ -542,7 +542,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     // Get add input feature map
@@ -612,7 +612,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     // Get add input feature map
@@ -691,7 +691,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     // Get add input feature map
@@ -764,7 +764,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     // Get add input feature map
@@ -836,7 +836,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     // Get add input feature map
@@ -917,7 +917,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     // Get add input feature map
@@ -1061,7 +1061,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
     auto smallestFPValueAttr = rewriter.getFloatAttr(
         elementType,
@@ -1225,7 +1225,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
     auto smallestFPValueAttr = rewriter.getFloatAttr(
         elementType,
@@ -1367,7 +1367,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
     auto smallestFPValueAttr = rewriter.getFloatAttr(
         elementType,
@@ -1521,7 +1521,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
     auto smallestFPValueAttr = rewriter.getFloatAttr(
         elementType,
@@ -1615,7 +1615,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     Value softmaxVal =
@@ -1652,7 +1652,7 @@ public:
     auto resultTensorType = RankedTensorType::get(torchTensorTy.getSizes(),
                                                   torchTensorTy.getDtype());
 
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultTensorType.getShape(), elementType);
 
     Value globalavgVal = rewriter
@@ -1688,7 +1688,7 @@ public:
         op->getResult(0).getType().cast<Torch::BaseTensorType>();
     auto resultType = RankedTensorType::get(torchResultType.getSizes(),
                                             torchResultType.getDtype());
-    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+    Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, resultType.getShape(), resultType.getElementType());
 
     Value linearVal =
@@ -1743,7 +1743,7 @@ public:
     ConversionTarget target(*context);
 
     target.addIllegalDialect<XTenDialect>();
-    target.addLegalDialect<linalg::LinalgDialect, arith::ArithmeticDialect,
+    target.addLegalDialect<linalg::LinalgDialect, arith::ArithDialect,
                            scf::SCFDialect, tensor::TensorDialect,
                            Torch::TorchDialect,
                            TorchConversion::TorchConversionDialect>();

--- a/lib/Dialect/XTen/IR/XTenOpStats.cpp
+++ b/lib/Dialect/XTen/IR/XTenOpStats.cpp
@@ -15,7 +15,7 @@
 
 #include "xten/Util/Util.h"
 
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 

--- a/lib/Dialect/XTen/IR/XTenOpStats.cpp
+++ b/lib/Dialect/XTen/IR/XTenOpStats.cpp
@@ -38,11 +38,11 @@ template<class T>
 std::map<std::string, uint64_t> getConv2dStatisticsWithType(T o, TensorType resultTy) {
     std::map<std::string, uint64_t> toReturn;
 
-    TensorType inputTy = o.input().getType().template cast<TensorType>();
-    TensorType weightTy = o.weight().getType().template cast<TensorType>();
+    TensorType inputTy = o.getInput().getType().template cast<TensorType>();
+    TensorType weightTy = o.getWeight().getType().template cast<TensorType>();
     TensorType biasTy;
-    if(o.bias()) {
-        biasTy = o.bias().getType().template cast<TensorType>();
+    if(o.getBias()) {
+        biasTy = o.getBias().getType().template cast<TensorType>();
     }
 
 
@@ -53,7 +53,7 @@ std::map<std::string, uint64_t> getConv2dStatisticsWithType(T o, TensorType resu
     uint64_t kernel_height = weightTy.getShape()[2];
     uint64_t kernel_width = weightTy.getShape()[3];
 
-    auto co = cast<arith::ConstantOp>(o.groups().getDefiningOp());
+    auto co = cast<arith::ConstantOp>(o.getGroups().getDefiningOp());
     auto ia = co->template getAttrOfType<IntegerAttr>("value");
     uint64_t groups = ia.getValue().getZExtValue();
     // Number of forward MACs per pixel =
@@ -64,7 +64,7 @@ std::map<std::string, uint64_t> getConv2dStatisticsWithType(T o, TensorType resu
     uint64_t ifm_volume = xilinx::xten::getTensorVolume(inputTy);
     uint64_t weight_volume = xilinx::xten::getTensorVolume(weightTy);
     uint64_t bias_volume;
-    if(o.bias()) {
+    if(o.getBias()) {
         bias_volume = xilinx::xten::getTensorVolume(biasTy);
     } else {
         bias_volume = 0;
@@ -96,8 +96,8 @@ uint64_t getConv2dOperandTransferVolumeWithType(T o, unsigned int idx, bool read
   if (simple_conv2d_model)
     return vol;
 
-  TensorType inputTy = o.input().getType().template cast<TensorType>();
-  TensorType weightTy = o.weight().getType().template cast<TensorType>();
+  TensorType inputTy = o.getInput().getType().template cast<TensorType>();
+  TensorType weightTy = o.getWeight().getType().template cast<TensorType>();
 
   float filter_width = weightTy.getShape()[2];
   float filter_height = weightTy.getShape()[3];
@@ -149,7 +149,7 @@ uint64_t getConv2dOperandTransferVolumeWithType(T o, unsigned int idx, bool read
 template<class T>
 uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx, bool write, TensorType resultTy) {
 
-  TensorType inputTy = o.input().getType().template cast<TensorType>();
+  TensorType inputTy = o.getInput().getType().template cast<TensorType>();
 
   if (simple_conv2d_model) {
     if (write)
@@ -158,7 +158,7 @@ uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx, bool write
       return 0;
   }
 
-  TensorType weightTy = o.weight().getType().template cast<TensorType>();
+  TensorType weightTy = o.getWeight().getType().template cast<TensorType>();
   float filter_width = weightTy.getShape()[2];
   //float filter_height = weightTy.getShape()[3];
 

--- a/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
+++ b/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
@@ -13,7 +13,7 @@
 
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 
 // TODO generate this file automatically
 

--- a/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
+++ b/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
@@ -35,7 +35,7 @@ namespace xilinx {
         }
 
         Value Conv2dOpWrapper::getWeights() {
-            return this->conv.weight();
+            return this->conv.getWeight();
         }
 
         ArrayRef<Value> Conv2dOpWrapper::getBN() {
@@ -43,11 +43,11 @@ namespace xilinx {
         }
 
         Optional<Value> Conv2dOpWrapper::getBiases() {
-            return this->conv.bias();
+            return this->conv.getBias();
         }
 
         Value Conv2dOpWrapper::getInput() {
-            return this->conv.input();
+            return this->conv.getInput();
         }
 
         Value Conv2dOpWrapper::getPartialInput() {
@@ -55,15 +55,15 @@ namespace xilinx {
         }
 
         unsigned int Conv2dOpWrapper::getF0() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
         }
 
         unsigned int Conv2dOpWrapper::getF1() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
         }
 
         unsigned int Conv2dOpWrapper::getStride() {
-            Value s = this->conv.stride();
+            Value s = this->conv.getStride();
             SmallVector<int64_t, 2> stride;
             matchPattern(s, Torch::m_TorchConstantIntList(stride));
 
@@ -84,12 +84,12 @@ namespace xilinx {
         }
 
         bool Conv2dOpWrapper::isDepthWise() {
-            //unsigned int groups = this->conv.groups().getDefiningOp<mlir::torch::Torch::IntType>().get();//.value();
-          llvm::APInt intT = this->conv.groups().getDefiningOp<mlir::torch::Torch::ConstantIntOp>().value();
+            //unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::torch::Torch::IntType>().get();//.value();
+          llvm::APInt intT = this->conv.getGroups().getDefiningOp<mlir::torch::Torch::ConstantIntOp>().value();
             //MLIRContext *context = intT.getContext();
           uint64_t groups = intT.getSExtValue();
 
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.input().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
+            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
             ArrayRef<int64_t> aShapeAR = aShape.getSizes();
 
             uint64_t C = aShapeAR[C_LOC];
@@ -114,7 +114,7 @@ namespace xilinx {
                 assert(bias.has_value());
             }
 
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.bias();
+            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
 
             Operation* op = this->getUnderlyingOperation();
             if(firstInPartialChain || partialIn.has_value()) {
@@ -125,10 +125,10 @@ namespace xilinx {
                                                                   chainIn,
                                                                   weight.value(),
                                                                   biasVal,
-                                                                  this->conv.stride(),
-                                                                  this->conv.padding(),
-                                                                  this->conv.dilation(),
-                                                                  this->conv.groups());
+                                                                  this->conv.getStride(),
+                                                                  this->conv.getPadding(),
+                                                                  this->conv.getDilation(),
+                                                                  this->conv.getGroups());
 
                 nOp->setAttrs(op->getAttrs());
 
@@ -139,10 +139,10 @@ namespace xilinx {
                                                           input,
                                                           weight.value(),
                                                           biasVal,
-                                                          this->conv.stride(),
-                                                          this->conv.padding(),
-                                                          this->conv.dilation(),
-                                                          this->conv.groups());
+                                                          this->conv.getStride(),
+                                                          this->conv.getPadding(),
+                                                          this->conv.getDilation(),
+                                                          this->conv.getGroups());
 
                 nOp->setAttrs(op->getAttrs());
 
@@ -160,10 +160,10 @@ namespace xilinx {
                                                       nullptr,
                                                       this->getWeights(),
                                                       this->getBiases().value_or(nullptr),
-                                                      this->conv.stride(),
-                                                      this->conv.padding(),
-                                                      this->conv.dilation(),
-                                                      this->conv.groups());
+                                                      this->conv.getStride(),
+                                                      this->conv.getPadding(),
+                                                      this->conv.getDilation(),
+                                                      this->conv.getGroups());
 
             } else {
                 op = builder.create<Conv2dOp>(builder.getUnknownLoc(),
@@ -171,10 +171,10 @@ namespace xilinx {
                                               this->getInput(),
                                               this->getWeights(),
                                               this->getBiases().value_or(nullptr),
-                                              this->conv.stride(),
-                                              this->conv.padding(),
-                                              this->conv.dilation(),
-                                              this->conv.groups());
+                                              this->conv.getStride(),
+                                              this->conv.getPadding(),
+                                              this->conv.getDilation(),
+                                              this->conv.getGroups());
             }
 
             op->setAttrs(this->getUnderlyingOperation()->getAttrs());
@@ -197,7 +197,7 @@ namespace xilinx {
         }
 
         Value PartialConv2dOpWrapper::getWeights() {
-            return this->conv.weight();
+            return this->conv.getWeight();
         }
 
         ArrayRef<Value> PartialConv2dOpWrapper::getBN() {
@@ -205,27 +205,27 @@ namespace xilinx {
         }
 
         Optional<Value> PartialConv2dOpWrapper::getBiases() {
-            return this->conv.bias();
+            return this->conv.getBias();
         }
 
         Value PartialConv2dOpWrapper::getInput() {
-            return this->conv.input();
+            return this->conv.getInput();
         }
 
         Value PartialConv2dOpWrapper::getPartialInput() {
-            return this->conv.PartialIn();
+            return this->conv.getPartialIn();
         }
 
         unsigned int PartialConv2dOpWrapper::getF0() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
         }
 
         unsigned int PartialConv2dOpWrapper::getF1() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
         }
 
         unsigned int PartialConv2dOpWrapper::getStride() {
-            Value s = this->conv.stride();
+            Value s = this->conv.getStride();
             SmallVector<int64_t, 2> stride;
             matchPattern(s, Torch::m_TorchConstantIntList(stride));
             return stride[0];
@@ -244,8 +244,8 @@ namespace xilinx {
         }
 
         bool PartialConv2dOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.groups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.input().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
+            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
+            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
             ArrayRef<int64_t> aShapeAR = aShape.getSizes();
 
             int64_t C = aShapeAR[C_LOC];
@@ -269,13 +269,13 @@ namespace xilinx {
                 assert(bias.has_value());
             }
 
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.bias();
+            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
 
             Value chainIn;
             if(partialIn.has_value()) {
                 chainIn = partialIn.value();
-            } else if(this->conv.PartialIn()){
-                chainIn = this->conv.PartialIn();
+            } else if(this->conv.getPartialIn()){
+                chainIn = this->conv.getPartialIn();
             } else {
                 chainIn = Value();
             }
@@ -288,10 +288,10 @@ namespace xilinx {
                                                               chainIn,
                                                               weight.value(),
                                                               biasVal,
-                                                              this->conv.stride(),
-                                                              this->conv.padding(),
-                                                              this->conv.dilation(),
-                                                              this->conv.groups());
+                                                              this->conv.getStride(),
+                                                              this->conv.getPadding(),
+                                                              this->conv.getDilation(),
+                                                              this->conv.getGroups());
 
             nOp->setAttrs(op->getAttrs());
             return nOp;
@@ -304,24 +304,24 @@ namespace xilinx {
                 op = builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
                                                      resTypes.value(),
                                                      this->getInput(),
-                                                     this->conv.PartialIn(),
+                                                     this->conv.getPartialIn(),
                                                      this->getWeights(),
                                                      this->getBiases().value_or(nullptr),
-                                                     this->conv.stride(),
-                                                     this->conv.padding(),
-                                                     this->conv.dilation(),
-                                                     this->conv.groups());
+                                                     this->conv.getStride(),
+                                                     this->conv.getPadding(),
+                                                     this->conv.getDilation(),
+                                                     this->conv.getGroups());
             } else {
                 op = builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
                                                      this->getUnderlyingOperation()->getResultTypes(),
                                                      this->getInput(),
-                                                     this->conv.PartialIn(),
+                                                     this->conv.getPartialIn(),
                                                      this->getWeights(),
                                                      this->getBiases().value_or(nullptr),
-                                                     this->conv.stride(),
-                                                     this->conv.padding(),
-                                                     this->conv.dilation(),
-                                                     this->conv.groups());
+                                                     this->conv.getStride(),
+                                                     this->conv.getPadding(),
+                                                     this->conv.getDilation(),
+                                                     this->conv.getGroups());
             }
 
 
@@ -345,7 +345,7 @@ namespace xilinx {
         }
 
         Value Conv2dReLUOpWrapper::getWeights() {
-            return this->conv.weight();
+            return this->conv.getWeight();
         }
 
         ArrayRef<Value> Conv2dReLUOpWrapper::getBN() {
@@ -353,11 +353,11 @@ namespace xilinx {
         }
 
         Optional<Value> Conv2dReLUOpWrapper::getBiases() {
-            return this->conv.bias();
+            return this->conv.getBias();
         }
 
         Value Conv2dReLUOpWrapper::getInput() {
-            return this->conv.input();
+            return this->conv.getInput();
         }
 
         Value Conv2dReLUOpWrapper::getPartialInput() {
@@ -365,15 +365,15 @@ namespace xilinx {
         }
 
         unsigned int Conv2dReLUOpWrapper::getF0() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
         }
 
         unsigned int Conv2dReLUOpWrapper::getF1() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
         }
 
         unsigned int Conv2dReLUOpWrapper::getStride() {
-            Value s = this->conv.stride();
+            Value s = this->conv.getStride();
             SmallVector<int64_t,2> stride;
             matchPattern(s, Torch::m_TorchConstantIntList(stride));
 
@@ -393,8 +393,8 @@ namespace xilinx {
         }
 
         bool Conv2dReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.groups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.input().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
+            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
+            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
             ArrayRef<int64_t> aShapeAR = aShape.getSizes();
 
             int64_t C = aShapeAR[C_LOC];
@@ -420,7 +420,7 @@ namespace xilinx {
             }
 
             Operation* op = this->getUnderlyingOperation();
-            Value biasVal = (bias.has_value()) ? bias.value() : this->conv.bias();
+            Value biasVal = (bias.has_value()) ? bias.value() : this->conv.getBias();
 
             if(firstInPartialChain || partialIn.has_value()) {
                 Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
@@ -430,10 +430,10 @@ namespace xilinx {
                                                                       chainIn,
                                                                       weight.value(),
                                                                       biasVal,
-                                                                      this->conv.stride(),
-                                                                      this->conv.padding(),
-                                                                      this->conv.dilation(),
-                                                                      this->conv.groups());
+                                                                      this->conv.getStride(),
+                                                                      this->conv.getPadding(),
+                                                                      this->conv.getDilation(),
+                                                                      this->conv.getGroups());
 
                 nOp->setAttrs(op->getAttrs());
                 return nOp;
@@ -443,10 +443,10 @@ namespace xilinx {
                                                               input,
                                                               weight.value(),
                                                               biasVal,
-                                                              this->conv.stride(),
-                                                              this->conv.padding(),
-                                                              this->conv.dilation(),
-                                                              this->conv.groups());
+                                                              this->conv.getStride(),
+                                                              this->conv.getPadding(),
+                                                              this->conv.getDilation(),
+                                                              this->conv.getGroups());
 
                 nOp->setAttrs(op->getAttrs());
                 return nOp;
@@ -463,20 +463,20 @@ namespace xilinx {
                                                           Value(),
                                                           this->getWeights(),
                                                           this->getBiases().value_or(nullptr),
-                                                          this->conv.stride(),
-                                                          this->conv.padding(),
-                                                          this->conv.dilation(),
-                                                          this->conv.groups());
+                                                          this->conv.getStride(),
+                                                          this->conv.getPadding(),
+                                                          this->conv.getDilation(),
+                                                          this->conv.getGroups());
             } else {
                 op = builder.create<Conv2dReLUOp>(builder.getUnknownLoc(),
                                                   this->getUnderlyingOperation()->getResultTypes(),
                                                   this->getInput(),
                                                   this->getWeights(),
                                                   this->getBiases().value_or(nullptr),
-                                                  this->conv.stride(),
-                                                  this->conv.padding(),
-                                                  this->conv.dilation(),
-                                                  this->conv.groups());
+                                                  this->conv.getStride(),
+                                                  this->conv.getPadding(),
+                                                  this->conv.getDilation(),
+                                                  this->conv.getGroups());
             }
 
 
@@ -500,7 +500,7 @@ namespace xilinx {
         }
 
         Value PartialConv2dReLUOpWrapper::getWeights() {
-            return this->conv.weight();
+            return this->conv.getWeight();
         }
 
         ArrayRef<Value> PartialConv2dReLUOpWrapper::getBN() {
@@ -508,27 +508,27 @@ namespace xilinx {
         }
 
         Optional<Value> PartialConv2dReLUOpWrapper::getBiases() {
-            return this->conv.bias();
+            return this->conv.getBias();
         }
 
         Value PartialConv2dReLUOpWrapper::getInput() {
-            return this->conv.input();
+            return this->conv.getInput();
         }
 
         Value PartialConv2dReLUOpWrapper::getPartialInput() {
-            return this->conv.PartialIn();
+            return this->conv.getPartialIn();
         }
 
         unsigned int PartialConv2dReLUOpWrapper::getF0() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
         }
 
         unsigned int PartialConv2dReLUOpWrapper::getF1() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
         }
 
         unsigned int PartialConv2dReLUOpWrapper::getStride() {
-            Value s = this->conv.stride();
+            Value s = this->conv.getStride();
             SmallVector<int64_t,2> stride;
             matchPattern(s, Torch::m_TorchConstantIntList(stride));
 
@@ -548,8 +548,8 @@ namespace xilinx {
         }
 
         bool PartialConv2dReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.groups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.input().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
+            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
+            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
             ArrayRef<int64_t> aShapeAR = aShape.getSizes();
 
             int64_t C = aShapeAR[C_LOC];
@@ -578,13 +578,13 @@ namespace xilinx {
             Value chainIn;
             if(partialIn.has_value()) {
                 chainIn = partialIn.value();
-            } else if(this->conv.PartialIn()){
-                chainIn = this->conv.PartialIn();
+            } else if(this->conv.getPartialIn()){
+                chainIn = this->conv.getPartialIn();
             } else {
                 chainIn = Value();
             }
 
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.bias();
+            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
 
             Operation* op = this->getUnderlyingOperation();
             Operation* nOp = builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
@@ -593,10 +593,10 @@ namespace xilinx {
                                                                  chainIn,
                                                                  weight.value(),
                                                                  biasVal,
-                                                                 this->conv.stride(),
-                                                                 this->conv.padding(),
-                                                                 this->conv.dilation(),
-                                                                 this->conv.groups());
+                                                                 this->conv.getStride(),
+                                                                 this->conv.getPadding(),
+                                                                 this->conv.getDilation(),
+                                                                 this->conv.getGroups());
             nOp->setAttrs(op->getAttrs());
             return nOp;
         }
@@ -608,24 +608,24 @@ namespace xilinx {
                 op = builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
                                                          resTypes.value(),
                                                          this->getInput(),
-                                                         this->conv.PartialIn(),
+                                                         this->conv.getPartialIn(),
                                                          this->getWeights(),
                                                          this->getBiases().value_or(nullptr),
-                                                         this->conv.stride(),
-                                                         this->conv.padding(),
-                                                         this->conv.dilation(),
-                                                         this->conv.groups());
+                                                         this->conv.getStride(),
+                                                         this->conv.getPadding(),
+                                                         this->conv.getDilation(),
+                                                         this->conv.getGroups());
             } else {
                 op = builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
                                                          this->getUnderlyingOperation()->getResultTypes(),
                                                          this->getInput(),
-                                                         this->conv.PartialIn(),
+                                                         this->conv.getPartialIn(),
                                                          this->getWeights(),
                                                          this->getBiases().value_or(nullptr),
-                                                         this->conv.stride(),
-                                                         this->conv.padding(),
-                                                         this->conv.dilation(),
-                                                         this->conv.groups());
+                                                         this->conv.getStride(),
+                                                         this->conv.getPadding(),
+                                                         this->conv.getDilation(),
+                                                         this->conv.getGroups());
             }
 
 
@@ -650,35 +650,35 @@ namespace xilinx {
         }
 
         Value PartialConv2dBatchNormReLUOpWrapper::getWeights() {
-            return this->conv.weight();
+            return this->conv.getWeight();
         }
 
         ArrayRef<Value> PartialConv2dBatchNormReLUOpWrapper::getBN() {
-            return ArrayRef<Value>({this->conv.bn_weight(), this->conv.bn_bias(), this->conv.running_mean(), this->conv.running_var()});
+            return ArrayRef<Value>({this->conv.getBnWeight(), this->conv.getBnBias(), this->conv.getRunningMean(), this->conv.getRunningVar()});
         }
 
         Optional<Value> PartialConv2dBatchNormReLUOpWrapper::getBiases() {
-            return this->conv.bias();
+            return this->conv.getBias();
         }
 
         Value PartialConv2dBatchNormReLUOpWrapper::getInput() {
-            return this->conv.input();
+            return this->conv.getInput();
         }
 
         Value PartialConv2dBatchNormReLUOpWrapper::getPartialInput() {
-            return this->conv.PartialIn();
+            return this->conv.getPartialIn();
         }
 
         unsigned int PartialConv2dBatchNormReLUOpWrapper::getF0() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
         }
 
         unsigned int PartialConv2dBatchNormReLUOpWrapper::getF1() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
         }
 
         unsigned int PartialConv2dBatchNormReLUOpWrapper::getStride() {
-            Value s = this->conv.stride();
+            Value s = this->conv.getStride();
             SmallVector<int64_t,2 > stride;
             matchPattern(s, Torch::m_TorchConstantIntList(stride));
 
@@ -698,8 +698,8 @@ namespace xilinx {
         }
 
         bool PartialConv2dBatchNormReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.groups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.input().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
+            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
+            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
             ArrayRef<int64_t> aShapeAR = aShape.getSizes();
 
             int64_t C = aShapeAR[C_LOC];
@@ -729,13 +729,13 @@ namespace xilinx {
             Value chainIn;
             if(partialIn.has_value()) {
                 chainIn = partialIn.value();
-            } else if(this->conv.PartialIn()){
-                chainIn = this->conv.PartialIn();
+            } else if(this->conv.getPartialIn()){
+                chainIn = this->conv.getPartialIn();
             } else {
                 chainIn = Value();
             }
 
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.bias();
+            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
 
             Operation* op = this->getUnderlyingOperation();
             Operation* nOp = builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
@@ -744,17 +744,17 @@ namespace xilinx {
                                                                           chainIn,
                                                                           weight.value(),
                                                                           biasVal,
-                                                                          this->conv.stride(),
-                                                                          this->conv.padding(),
-                                                                          this->conv.dilation(),
-                                                                          this->conv.groups(),
+                                                                          this->conv.getStride(),
+                                                                          this->conv.getPadding(),
+                                                                          this->conv.getDilation(),
+                                                                          this->conv.getGroups(),
                                                                           bn.value()[0],
                                                                           bn.value()[1],
                                                                           bn.value()[2],
                                                                           bn.value()[3],
-                                                                          this->conv.training(),
-                                                                          this->conv.momentum(),
-                                                                          this->conv.eps());
+                                                                          this->conv.getTraining(),
+                                                                          this->conv.getMomentum(),
+                                                                          this->conv.getEps());
 
             nOp->setAttrs(op->getAttrs());
             return nOp;
@@ -766,38 +766,38 @@ namespace xilinx {
                 op = builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
                                                                   resTypes.value(),
                                                                   this->getInput(),
-                                                                  this->conv.PartialIn(),
+                                                                  this->conv.getPartialIn(),
                                                                   this->getWeights(),
                                                                   this->getBiases().value_or(nullptr),
-                                                                  this->conv.stride(),
-                                                                  this->conv.padding(),
-                                                                  this->conv.dilation(),
-                                                                  this->conv.groups(),
-                                                                  this->conv.bn_weight(),
-                                                                  this->conv.bn_bias(),
-                                                                  this->conv.running_mean(),
-                                                                  this->conv.running_var(),
-                                                                  this->conv.training(),
-                                                                  this->conv.momentum(),
-                                                                  this->conv.eps());
+                                                                  this->conv.getStride(),
+                                                                  this->conv.getPadding(),
+                                                                  this->conv.getDilation(),
+                                                                  this->conv.getGroups(),
+                                                                  this->conv.getBnWeight(),
+                                                                  this->conv.getBnBias(),
+                                                                  this->conv.getRunningMean(),
+                                                                  this->conv.getRunningVar(),
+                                                                  this->conv.getTraining(),
+                                                                  this->conv.getMomentum(),
+                                                                  this->conv.getEps());
             } else {
                 op = builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
                                                                   this->getUnderlyingOperation()->getResultTypes(),
                                                                   this->getInput(),
-                                                                  this->conv.PartialIn(),
+                                                                  this->conv.getPartialIn(),
                                                                   this->getWeights(),
                                                                   this->getBiases().value_or(nullptr),
-                                                                  this->conv.stride(),
-                                                                  this->conv.padding(),
-                                                                  this->conv.dilation(),
-                                                                  this->conv.groups(),
-                                                                  this->conv.bn_weight(),
-                                                                  this->conv.bn_bias(),
-                                                                  this->conv.running_mean(),
-                                                                  this->conv.running_var(),
-                                                                  this->conv.training(),
-                                                                  this->conv.momentum(),
-                                                                  this->conv.eps());
+                                                                  this->conv.getStride(),
+                                                                  this->conv.getPadding(),
+                                                                  this->conv.getDilation(),
+                                                                  this->conv.getGroups(),
+                                                                  this->conv.getBnWeight(),
+                                                                  this->conv.getBnBias(),
+                                                                  this->conv.getRunningMean(),
+                                                                  this->conv.getRunningVar(),
+                                                                  this->conv.getTraining(),
+                                                                  this->conv.getMomentum(),
+                                                                  this->conv.getEps());
             }
 
 
@@ -823,19 +823,19 @@ namespace xilinx {
         }
 
         Value Conv2dBatchNormReLUOpWrapper::getWeights() {
-            return this->conv.weight();
+            return this->conv.getWeight();
         }
 
         ArrayRef<Value> Conv2dBatchNormReLUOpWrapper::getBN() {
-            return ArrayRef<Value>({this->conv.bn_weight(), this->conv.bn_bias(), this->conv.running_mean(), this->conv.running_var()});
+            return ArrayRef<Value>({this->conv.getBnWeight(), this->conv.getBnBias(), this->conv.getRunningMean(), this->conv.getRunningVar()});
         }
 
         Optional<Value> Conv2dBatchNormReLUOpWrapper::getBiases() {
-            return this->conv.bias();
+            return this->conv.getBias();
         }
 
         Value Conv2dBatchNormReLUOpWrapper::getInput() {
-            return this->conv.input();
+            return this->conv.getInput();
         }
 
         Value Conv2dBatchNormReLUOpWrapper::getPartialInput() {
@@ -843,15 +843,15 @@ namespace xilinx {
         }
 
         unsigned int Conv2dBatchNormReLUOpWrapper::getF0() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
         }
 
         unsigned int Conv2dBatchNormReLUOpWrapper::getF1() {
-            return this->conv.weight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
+            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
         }
 
         unsigned int Conv2dBatchNormReLUOpWrapper::getStride() {
-            Value s = this->conv.stride();
+            Value s = this->conv.getStride();
             SmallVector<int64_t,2> stride;
             matchPattern(s, Torch::m_TorchConstantIntList(stride));
 
@@ -871,8 +871,8 @@ namespace xilinx {
         }
 
         bool Conv2dBatchNormReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.groups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.input().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
+            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
+            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
             ArrayRef<int64_t> aShapeAR = aShape.getSizes();
 
             int64_t C = aShapeAR[C_LOC];
@@ -899,7 +899,7 @@ namespace xilinx {
                 assert(bias.has_value());
             }
 
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.bias();
+            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
 
             Operation* op = this->getUnderlyingOperation();
             if(firstInPartialChain || partialIn.has_value()) {
@@ -910,17 +910,17 @@ namespace xilinx {
                                                                                chainIn,
                                                                                weight.value(),
                                                                                biasVal,
-                                                                               this->conv.stride(),
-                                                                               this->conv.padding(),
-                                                                               this->conv.dilation(),
-                                                                               this->conv.groups(),
+                                                                               this->conv.getStride(),
+                                                                               this->conv.getPadding(),
+                                                                               this->conv.getDilation(),
+                                                                               this->conv.getGroups(),
                                                                                bn.value()[0],
                                                                                bn.value()[1],
                                                                                bn.value()[2],
                                                                                bn.value()[3],
-                                                                               this->conv.training(),
-                                                                               this->conv.momentum(),
-                                                                               this->conv.eps());
+                                                                               this->conv.getTraining(),
+                                                                               this->conv.getMomentum(),
+                                                                               this->conv.getEps());
                 nOp->setAttrs(op->getAttrs());
 
                 return nOp;
@@ -930,17 +930,17 @@ namespace xilinx {
                                                                        input,
                                                                        weight.value(),
                                                                        biasVal,
-                                                                       this->conv.stride(),
-                                                                       this->conv.padding(),
-                                                                       this->conv.dilation(),
-                                                                       this->conv.groups(),
+                                                                       this->conv.getStride(),
+                                                                       this->conv.getPadding(),
+                                                                       this->conv.getDilation(),
+                                                                       this->conv.getGroups(),
                                                                        bn.value()[0],
                                                                        bn.value()[1],
                                                                        bn.value()[2],
                                                                        bn.value()[3],
-                                                                       this->conv.training(),
-                                                                       this->conv.momentum(),
-                                                                       this->conv.eps());
+                                                                       this->conv.getTraining(),
+                                                                       this->conv.getMomentum(),
+                                                                       this->conv.getEps());
 
                 nOp->setAttrs(op->getAttrs());
 
@@ -958,34 +958,34 @@ namespace xilinx {
                                                                    Value(),
                                                                    this->getWeights(),
                                                                    this->getBiases().value_or(nullptr),
-                                                                   this->conv.stride(),
-                                                                   this->conv.padding(),
-                                                                   this->conv.dilation(),
-                                                                   this->conv.groups(),
-                                                                   this->conv.bn_weight(),
-                                                                   this->conv.bn_bias(),
-                                                                   this->conv.running_mean(),
-                                                                   this->conv.running_var(),
-                                                                   this->conv.training(),
-                                                                   this->conv.momentum(),
-                                                                   this->conv.eps());
+                                                                   this->conv.getStride(),
+                                                                   this->conv.getPadding(),
+                                                                   this->conv.getDilation(),
+                                                                   this->conv.getGroups(),
+                                                                   this->conv.getBnWeight(),
+                                                                   this->conv.getBnBias(),
+                                                                   this->conv.getRunningMean(),
+                                                                   this->conv.getRunningVar(),
+                                                                   this->conv.getTraining(),
+                                                                   this->conv.getMomentum(),
+                                                                   this->conv.getEps());
             } else {
                 op = builder.create<Conv2dBatchNormReLUOp>(builder.getUnknownLoc(),
                                                            this->getUnderlyingOperation()->getResultTypes(),
                                                            this->getInput(),
                                                            this->getWeights(),
                                                            this->getBiases().value_or(nullptr),
-                                                           this->conv.stride(),
-                                                           this->conv.padding(),
-                                                           this->conv.dilation(),
-                                                           this->conv.groups(),
-                                                           this->conv.bn_weight(),
-                                                           this->conv.bn_bias(),
-                                                           this->conv.running_mean(),
-                                                           this->conv.running_var(),
-                                                           this->conv.training(),
-                                                           this->conv.momentum(),
-                                                           this->conv.eps());
+                                                           this->conv.getStride(),
+                                                           this->conv.getPadding(),
+                                                           this->conv.getDilation(),
+                                                           this->conv.getGroups(),
+                                                           this->conv.getBnWeight(),
+                                                           this->conv.getBnBias(),
+                                                           this->conv.getRunningMean(),
+                                                           this->conv.getRunningVar(),
+                                                           this->conv.getTraining(),
+                                                           this->conv.getMomentum(),
+                                                           this->conv.getEps());
             }
 
 

--- a/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
+++ b/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
@@ -84,9 +84,7 @@ namespace xilinx {
         }
 
         bool Conv2dOpWrapper::isDepthWise() {
-            //unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::torch::Torch::IntType>().get();//.value();
           llvm::APInt intT = this->conv.getGroups().getDefiningOp<mlir::torch::Torch::ConstantIntOp>().value();
-            //MLIRContext *context = intT.getContext();
           uint64_t groups = intT.getSExtValue();
 
             mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();

--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -46,7 +46,7 @@ namespace {
 
 template <class Op>
 llvm::Optional<Value> getAlpha(Op &reluOp) {
-  return reluOp.alpha();
+  return reluOp.getAlpha();
 }
 
 template <>
@@ -399,11 +399,11 @@ private:
   }
 
   void fillProperties(xten::MMOp &op, JsonPropertiesBuilder &&props) {
-    fillOther(op, op.y(), props);
+    fillOther(op, op.getY(), props);
   }
 
   void fillProperties(xten::AddOp &op, JsonPropertiesBuilder &&props) {
-    fillOther(op, op.input1(), props);
+    fillOther(op, op.getInput1(), props);
   }
 
   void fillPropertiesCatOp(Torch::AtenCatOp &op,
@@ -414,21 +414,67 @@ private:
     //  fillPropertiesObject({"Storage.Bytes", storage_str}, propertiesArray);
   }
 
+  template <class ConvOp>
+  inline Value getWeight(ConvOp op) {
+    return op.getWeight();
+  }
+
+  template <>
+  inline Value getWeight(Torch::AtenConvolutionOp op) {
+    return op.weight();
+  }
+
+  template <class ConvOp>
+  inline Value getBias(ConvOp op) {
+    return op.getBias();
+  }
+
+  template <>
+  inline Value getBias(Torch::AtenConvolutionOp op) {
+    return op.bias();
+  }
+
+  template <class ConvOp>
+  inline Value getConvPadding(ConvOp op) {
+    return op.getPadding();
+  }
+
+  template <>
+  inline Value getConvPadding(Torch::AtenConvolutionOp op) {
+    return op.padding();
+  }
+
+  template <class ConvOp>
+  inline Value getConvStride(ConvOp op) {
+    return op.getStride();
+  }
+
+  template <>
+  inline Value getConvStride(Torch::AtenConvolutionOp op) {
+    return op.stride();
+  }
+
+  template <class ConvOp>
+  inline Value getDilation(ConvOp op) {
+    return op.getDilation();
+  }
+
+  template <>
+  inline Value getDilation(Torch::AtenConvolutionOp op) {
+    return op.dilation();
+  }
+
   template <class T>
   uint64_t fillPropertiesConvOp(T &op, JsonPropertiesBuilder &&props) {
-
-    Value weight = op.weight();
-    Value bias = op.bias();
-
     // note that the shape originally was written out as ?o?c?h?w,
     // now it's ?x?x?x? like everywhere else.
     auto bytes = 0;
-    bytes += props.appendTypeInfo("Attributes.Weights", weight.getType());
-    bytes += props.appendTypeInfo("Attributes.Bias", bias.getType());
+    bytes += props.appendTypeInfo("Attributes.Weights", getWeight(op).getType());
+    bytes += props.appendTypeInfo("Attributes.Bias", getBias(op).getType());
 
 
     Torch::BaseTensorType weightTy =
-        weight.getType().cast<Torch::BaseTensorType>();
+        getWeight(op).getType().template cast<Torch::BaseTensorType>();
 
     // h,w
     std::string kernel_shape =
@@ -436,9 +482,9 @@ private:
         + "," + std::to_string( weightTy.getSizes()[3]);
 
     props.append("Attributes.kernel shape", kernel_shape);
-    props.appendIntList("Attributes.padding", op.padding());
-    props.appendIntList("Attributes.stride", op.stride());
-    props.appendIntList("Attributes.dilation", op.dilation());
+    props.appendIntList("Attributes.padding", getConvPadding(op));
+    props.appendIntList("Attributes.stride", getConvStride(op));
+    props.appendIntList("Attributes.dilation", getDilation(op));
 
     std::map<std::string, uint64_t> layerStatsMap = getLayerStatsMap(op);
     props.append("Computations.MAC", std::to_string(layerStatsMap["ops:MAC"]));
@@ -449,17 +495,17 @@ private:
 
   template <class MaxpoolOp>
   Value getKernelSize(MaxpoolOp &maxPoolOp) {
-    return maxPoolOp.mp_kernel_size();
+    return maxPoolOp.getMpKernelSize();
   }
 
   template <class MaxpoolOp>
   Value getStride(MaxpoolOp &maxPoolOp) {
-    return maxPoolOp.mp_stride();
+    return maxPoolOp.getMpStride();
   }
 
   template <class MaxpoolOp>
   Value getPadding(MaxpoolOp &maxPoolOp) {
-    return maxPoolOp.mp_padding();
+    return maxPoolOp.getMpPadding();
   }
 
   template <>
@@ -532,11 +578,27 @@ private:
     return bytes;
   }
 
+  inline Value getWeight(Torch::AtenLinearOp linOp) {
+    return linOp.weight();
+  }
+
+  inline Value getWeight(xten::LinearOp xtenLinOp) {
+    return xtenLinOp.getWeight();
+  }
+
+  inline Value getBias(Torch::AtenLinearOp linOp) {
+    return linOp.bias();
+  }
+
+  inline Value getBias(xten::LinearOp xtenLinOp) {
+    return xtenLinOp.getBias();
+  }
+
   template <typename LinearOpType>
   void fillPropertiesLinearOp(LinearOpType &op, JsonPropertiesBuilder &&props) {
     auto bytes = 0;
-    bytes += props.appendTypeInfo("Attributes.Weights", op.weight().getType());
-    bytes += props.appendTypeInfo("Attributes.Bias", op.bias().getType());
+    bytes += props.appendTypeInfo("Attributes.Weights", getWeight(op).getType());
+    bytes += props.appendTypeInfo("Attributes.Bias", getBias(op).getType());
     props.appendStorageAttr(op, bytes);
   }
 
@@ -545,7 +607,7 @@ private:
   }
 
   inline Value getBnWeight(xten::Conv2dBatchNormReLUOp xtenBnOp) {
-    return xtenBnOp.bn_weight();
+    return xtenBnOp.getBnWeight();
   }
 
   inline Value getBnBias(Torch::AtenBatchNormOp bnOp) {
@@ -553,7 +615,39 @@ private:
   }
 
   inline Value getBnBias(xten::Conv2dBatchNormReLUOp xtenBnOp) {
-    return xtenBnOp.bn_bias();
+    return xtenBnOp.getBnBias();
+  }
+
+  inline Value getRunningMean(Torch::AtenBatchNormOp bnOp) {
+    return bnOp.running_mean();
+  }
+
+  inline Value getRunningMean(xten::Conv2dBatchNormReLUOp xtenBnOp) {
+    return xtenBnOp.getRunningMean();
+  }
+
+  inline Value getRunningVar(Torch::AtenBatchNormOp bnOp) {
+    return bnOp.running_var();
+  }
+
+  inline Value getRunningVar(xten::Conv2dBatchNormReLUOp xtenBnOp) {
+    return xtenBnOp.getRunningVar();
+  }
+
+  inline Value getEps(Torch::AtenBatchNormOp bnOp) {
+    return bnOp.eps();
+  }
+
+  inline Value getEps(xten::Conv2dBatchNormReLUOp xtenBnOp) {
+    return xtenBnOp.getEps();
+  }
+
+  inline Value getMomentum(Torch::AtenBatchNormOp bnOp) {
+    return bnOp.momentum();
+  }
+
+  inline Value getMomentum(xten::Conv2dBatchNormReLUOp xtenBnOp) {
+    return xtenBnOp.getMomentum();
   }
 
   template <class T>
@@ -563,13 +657,13 @@ private:
         props.appendTypeInfo("Attributes.Weights", getBnWeight(op).getType());
     bytes += props.appendTypeInfo("Attributes.Bias", getBnBias(op).getType());
     bytes +=
-        props.appendTypeInfo("Attributes.Weights", op.running_mean().getType());
+        props.appendTypeInfo("Attributes.Weights", getRunningMean(op).getType());
     bytes +=
-        props.appendTypeInfo("Attributes.Variance", op.running_var().getType());
+        props.appendTypeInfo("Attributes.Variance", getRunningVar(op).getType());
     props.appendStorageAttr(op, bytes);
 
-    props.appendFloatValue("Attributes.eps", op.eps());
-    props.appendFloatValue("Attributes.momentum", op.momentum());
+    props.appendFloatValue("Attributes.eps", getEps(op));
+    props.appendFloatValue("Attributes.momentum", getMomentum(op));
     return bytes;
   }
 

--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -18,7 +18,7 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_lrelu_maxpool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_lrelu_maxpool.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-//CHECK:linalg.conv_2d_lrelu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_lrelu_maxpool0", mp_dilations = dense<1> : tensor<2xi64>, mp_kernel_size = dense<2> : tensor<2xi64>, mp_padding = dense<0> : tensor<4xi64>, mp_strides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
+// CHECK: linalg.conv_2d_lrelu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_lrelu_maxpool0", mpDilations = dense<1> : tensor<2xi64>, mpKernelSize = dense<2> : tensor<2xi64>, mpPadding = dense<0> : tensor<4xi64>, mpStrides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
 module attributes {torch.debug_module_name = "HelloWorld"}  {
   func.func @forward(%arg0: !torch.vtensor<[1,3,128,128],f32>) -> !torch.vtensor<[1,16,64,64],f32> {
     %0 = torch.vtensor.literal(dense<1.000000e+00> : tensor<16xf32>) : !torch.vtensor<[16],f32>

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_lrelu_pad_maxpool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_lrelu_pad_maxpool.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-//CHECK:linalg.conv_2d_lrelu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_lrelu_pad_maxpool0", mp_dilations = dense<1> : tensor<2xi64>, mp_kernel_size = dense<2> : tensor<2xi64>, mp_padding = dense<[0, 1, 0, 1]> : tensor<4xi64>, mp_strides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
+// CHECK: linalg.conv_2d_lrelu_maxpool  {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_lrelu_pad_maxpool0", mpDilations = dense<1> : tensor<2xi64>, mpKernelSize = dense<2> : tensor<2xi64>, mpPadding = dense<[0, 1, 0, 1]> : tensor<4xi64>, mpStrides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, f32) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
 module attributes {torch.debug_module_name = "HelloWorld"}  {
   func.func @forward(%arg0: !torch.vtensor<[1,3,128,128],f32>) -> !torch.vtensor<[1,16,64,64],f32> {
     %0 = torch.vtensor.literal(dense<1.000000e+00> : tensor<16xf32>) : !torch.vtensor<[16],f32>

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_relu_maxpool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_relu_maxpool.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-//CHECK:linalg.conv_2d_relu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_relu_maxpool0", mp_dilations = dense<1> : tensor<2xi64>, mp_kernel_size = dense<2> : tensor<2xi64>, mp_padding = dense<0> : tensor<4xi64>, mp_strides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
+// CHECK: linalg.conv_2d_relu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_relu_maxpool0", mpDilations = dense<1> : tensor<2xi64>, mpKernelSize = dense<2> : tensor<2xi64>, mpPadding = dense<0> : tensor<4xi64>, mpStrides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
 module attributes {torch.debug_module_name = "HelloWorld"}  {
   func.func @forward(%arg0: !torch.vtensor<[1,3,128,128],f32>) -> !torch.vtensor<[1,16,64,64],f32> {
     %0 = torch.vtensor.literal(dense<1.000000e+00> : tensor<16xf32>) : !torch.vtensor<[16],f32>

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_relu_pad_maxpool.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_conv2d_relu_pad_maxpool.mlir
@@ -9,8 +9,8 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aten-opt %s -xten-to-linalg | FileCheck %s
-//CHECK:tensor.pad {{.*}} low[0, 0, 1, 1] high[0, 0, 1, 1] 
-//CHECK:linalg.conv_2d_relu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_relu_pad_maxpool0", mp_dilations = dense<1> : tensor<2xi64>, mp_kernel_size = dense<2> : tensor<2xi64>, mp_padding = dense<[0, 1, 0, 1]> : tensor<4xi64>, mp_strides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}}: tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
+// CHECK: tensor.pad {{.*}} low[0, 0, 1, 1] high[0, 0, 1, 1] 
+// CHECK: linalg.conv_2d_relu_maxpool {dilations = dense<1> : tensor<2xi64>, layer_name = "conv2d_relu_pad_maxpool0", mpDilations = dense<1> : tensor<2xi64>, mpKernelSize = dense<2> : tensor<2xi64>, mpPadding = dense<[0, 1, 0, 1]> : tensor<4xi64>, mpStrides = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}}, {{.*}}, {{.*}} : tensor<1x3x130x130xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x64x64xf32>) -> tensor<1x16x64x64xf32>
 module attributes {torch.debug_module_name = "HelloWorld"}  {
   func.func @forward(%arg0: !torch.vtensor<[1,3,128,128],f32>) -> !torch.vtensor<[1,16,64,64],f32> {
     %0 = torch.vtensor.literal(dense<1.000000e+00> : tensor<16xf32>) : !torch.vtensor<[16],f32>

--- a/test/Conversion/XTenToLinalg/xten_to_linalg_linear.mlir
+++ b/test/Conversion/XTenToLinalg/xten_to_linalg_linear.mlir
@@ -21,7 +21,7 @@ func.func @test_convert_linear_bias_optional(%arg0: !torch.vtensor<[1,2048],f32>
     %optional_tensor = torch.derefine %none: !torch.none to !torch.optional<tensor>
     %0 = "xten.linear"(%arg0, %arg1, %optional_tensor) : (!torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.optional<tensor>) -> !torch.vtensor<[1,1000],f32>
     return %0 : !torch.vtensor<[1,1000],f32>
-// CHECK: %[[EMPTY:.+]] = linalg.init_tensor [1000] : tensor<1000xf32>
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1000xf32>
 // CHECK-NEXT: %[[CONSTANT:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT: %[[ZEROED:.+]] = linalg.fill ins(%[[CONSTANT]] : f32) outs(%[[EMPTY]] : tensor<1000xf32>) -> tensor<1000xf32>
 // CHECK: linalg.linear ins({{.+}}, {{.+}}, %[[ZEROED]] : tensor<1x2048xf32>, tensor<1000x2048xf32>, tensor<1000xf32>) outs({{.+}} : tensor<1x1000xf32>) -> tensor<1x1000xf32>
@@ -31,7 +31,7 @@ func.func @test_convert_linear_bias_none(%arg0: !torch.vtensor<[1,2048],f32>, %a
     %none = torch.constant.none
     %0 = "xten.linear"(%arg0, %arg1, %none) : (!torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.none) -> !torch.vtensor<[1,1000],f32>
     return %0 : !torch.vtensor<[1,1000],f32>
-// CHECK: %[[EMPTY:.+]] = linalg.init_tensor [1000] : tensor<1000xf32>
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1000xf32>
 // CHECK-NEXT: %[[CONSTANT:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT: %[[ZEROED:.+]] = linalg.fill ins(%[[CONSTANT]] : f32) outs(%[[EMPTY]] : tensor<1000xf32>) -> tensor<1000xf32>
 // CHECK: linalg.linear ins({{.+}}, {{.+}}, %[[ZEROED]] : tensor<1x2048xf32>, tensor<1000x2048xf32>, tensor<1000xf32>) outs({{.+}} : tensor<1x1000xf32>) -> tensor<1x1000xf32>


### PR DESCRIPTION
Notable changes are the renaming of the `NoSideEffect` attribute to `Pure`, the renaming of the `ArithmeticDialect` to `ArithDialect` as well as the changes to the interface generated from Tablegen, which is now prefixed with `get`, e.g. `getSrc()` instead of `src()`. Furthermore, `linalg.init_tensor` has been replaced with `tensor.empty()`