### PR TITLE
refactor: add xten_nn to output

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -36,7 +36,6 @@ def XTenNN_SubgraphOp : XTenNN_Op<"subgraph", [
             SingleBlockImplicitTerminator<"OutputOp">,
             XTenNN_EnclaveOp,
             IsolatedFromAbove,
-            OpAsmOpInterface,
             RecursivelySpeculatable,
             RecursiveMemoryEffects]> {
     let summary = "Separates a subgraph inside a graph";
@@ -66,14 +65,6 @@ def XTenNN_SubgraphOp : XTenNN_Op<"subgraph", [
     let hasCustomAssemblyFormat = 1;
     let hasVerifier = 1;
 
-
-    code extraClassDeclaration = [{
-    //===------------------------------------------------------------------===//
-    // OpAsmOpInterface
-    //===------------------------------------------------------------------===//
-
-    static llvm::StringRef getDefaultDialect() { return "xten_nn"; }
-    }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/XTenNN/simplify.mlir
+++ b/test/Dialect/XTenNN/simplify.mlir
@@ -4,7 +4,7 @@ func.func @net0() -> f64 {
     %unused = arith.constant 0.0 : f64
     %result = xten_nn.subgraph (%0 = %unused : f64) {
         %1 = arith.constant 1.0 : f64
-        output %1 : f64
+        xten_nn.output %1 : f64
     } -> f64
     return %result : f64
 // CHECK-LABEL: @net0(
@@ -18,13 +18,13 @@ func.func @net1() -> f64 {
     %r0, %r1 = xten_nn.subgraph () {
         %cst0 = arith.constant 0.0 : f64
         %cst1 = arith.constant 1.0 : f64
-        output %cst0, %cst1 : f64, f64
+        xten_nn.output %cst0, %cst1 : f64, f64
     } -> f64, f64
     return %r0 : f64
 // CHECK-LABEL: @net1(
 // CHECK: %[[r0:.+]] = xten_nn.subgraph () {
 // CHECK: %[[cst0:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK: output %[[cst0]] : f64
+// CHECK: xten_nn.output %[[cst0]] : f64
 // CHECK: } -> f64
 // CHECK: return %[[r0]] : f64
 }

--- a/test/Dialect/XTenNN/subgraph-invalid.mlir
+++ b/test/Dialect/XTenNN/subgraph-invalid.mlir
@@ -14,7 +14,7 @@ func.func @enclave_result_number_missmatch() -> f64 {
         %1 = arith.constant 1.0 : f64
         %2 = arith.constant 1.0 : f64
     // expected-error@+1 {{does not match number of results}}
-    output %1 : f64
+    xten_nn.output %1 : f64
     } -> f64, f64
     return %result1 : f64
 }
@@ -24,7 +24,7 @@ func.func @enclave_result_type_missmatch() -> f32 {
     %result1 = xten_nn.subgraph () {
         %1 = arith.constant 1.0 : f64
     // expected-error@+1 {{does not match result type}}
-    output %1 : f64
+    xten_nn.output %1 : f64
     } -> f32
     return %result1 : f32
 }


### PR DESCRIPTION
The "issue" was the `OpAsmOpInterface`. It has a special case for operations printed in the region that are in the same dialect. Here is the code for this: [AsmPrinter.cpp](https://github.com/llvm/llvm-project/blob/b95f54350c85f535282cf2d8cd5c5925febb27f8/mlir/lib/IR/AsmPrinter.cpp#L3302-L3305)