### PR TITLE
FXML-1219 Update Supported Ops

### DIFF
--- a/lib/Transform/operators_supported.json
+++ b/lib/Transform/operators_supported.json
@@ -1,545 +1,1679 @@
 {
-    "ops" : [
-	{
-	    "name" : "torch.aten.convolution",
-	    "properties" : [		
-		["Attributes.Weights.Tensor", "Dimensions of weights" , "string"],
-	        ["Attributes.Weights.type", "Numerical type of each Weights number" , "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],		
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    
-		["Computation.MACs", "Total number of MAC units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Convolution engine", "long"]
-	    ]		
-	},
-	{
-	    "name" : "torch.aten.max_pool2d",
-	    "properties" : [		
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    
-		["Computation.Vec Max", "Total number of Vec-Max units in engine", "long"],
-		["Storage.Bytes", "Total storage required for MaxPool2D engine", "long"]
-	    ]		
-	},
-	{
-	    "name" : "torch.aten.mean.dim",
-	    "properties" : [
-		["Attributes.dim", "List of dimensions to reduce", "string"],
-		["Attributes.keepdim", "If true, the mean dimensions are kept", "string"],
-		["Computation.Vec Max", "Total number of Vec-Max units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Mean engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "torch.aten.squeeze.dim",
-	    "properties" : [
-		["Attributes.dim", "The dimension of size 1 to remove", "int"],
-		["Storage.Bytes", "Total storage required for Squeeze engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "torch.aten.leaky_relu",
-	    "properties" : [
-		["Attributes.Alpha.Tensor", "Dimensions of alpha", "string"],
-		["Attributes.Alpha.type", "Numerical type of each alpha number", "string"],
-		["Attributes.Alpha.Bytes", "Size of alpha in bytes", "long"],
-		["Attributes.Alpha", "Value of alpha", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for LReLU engine", "long"]  		
-	    ]		
-	},
-	{
-	    "name" : "torch.aten.relu",
-	    "properties" : [
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for ReLU engine", "long"]  		
-	    ]		
-	},	
-	{
-	    "name" : "torch.aten.batch_norm",
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.Mean.Tensor", "Dimensions of mean", "string"],
-		["Attributes.Mean.type", "Numerical type of each Means number", "string"],
-		["Attributes.Mean.Byes", "Size of mean in bytes", "string"],      
-		["Attributes.Variance.Tensor", "Dimensions of variance", "string"],
-		["Attributes.Variance.type", "Numerical type of each Variances number", "string"],
-		["Attributes.Variance.Byes", "Size of variance in bytes", "string"],      
-		["Attributes.momentum", "Value of momentum", "long"],      
-		["Attributes.eps", "Value of epsilon", "long"],       
-		["Storage.Bytes", "Total storage required for NativeBatchNorm engine", "long"]
-	    ]	    
-	},
-	{
-	    "name" : "torch.aten.adaptive_avg_pool2d",
-	    "properties" : [		
-		["Attributes.output shape", "Dimensions of output", "string"],
-		["Computation.+", "Total number of + (addition) units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Adaptive Average Pool engine", "long"]
-	    ]		
-	},
-	{
- 	    "name" : "torch.aten.size_",
-	    "properties" : [		
-		["Storage.Bytes", "Total storage required for Size engine", "long"]
-	    ]		
-	},
-	{
- 	    "name" : "torch.aten.cat",
-	    "properties" : [		
-		["Storage.Bytes", "Total storage required for Cat engine", "long"]
-	    ]		
-	},
-	{
-	    "name" : "torch.aten.addmm",
-	    "properties" : [
-		["Attributes.Mat1.Tensor", "", "string"],
-		["Attributes.Mat1.type", "", "string"],
-		["Attributes.Mat1.Bytes", "", "long"],
-		["Attributes.Mat2.Tensor", "", "string"],
-		["Attributes.Mat2.type", "", "string"],
-		["Attributes.Mat2.Bytes", "", "long"],
-		["Attributes.alpha", "Value of alpha", "long"],
-		["Attributes.beta", "Value of beta", "long"],
-		["Computation.+", "Total number of + (addition) units in engine", "long"],
-		["Storage.Bytes", "Total storage required for AddMM engine", "long"]   
-	    ]
-	},
-	{
-	    "name" : "torch.aten.softmax",
-	    "properties" : [
-		["Attributes.dim", "Value of dimension along which Softmax is computed", "long"],
-		["Storage.Bytes", "Total storage required for Softmax engine", "string"]	
-	    ]
-	},
-	{
-	    "name" : "torch.aten._softmax",
-	    "properties" : [
-		["Attributes.dim", "Value of dimension along which Softmax is computed", "long"],
-		["Storage.Bytes", "Total storage required for Softmax engine", "string"]
-	    ]
-	},
-	{
-	    "name" : "torch.aten.log_softmax",
-	    "properties" : [
-		["Attributes.dim", "Value of dimension along which Softmax is computed", "long"],
-		["Storage.Bytes", "Total storage required for LogSoftmax engine", "string"]	
-	    ]
-	},
-	{
-	    "name" : "torch.aten.flatten.using_ints",
-	    "properties" : [
-		["Storage.Bytes", "Total storage required for Flatten engine", "string"]	
-	    ]
-	},
-	{
-	    "name" : "torch.aten.linear",
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights" , "string"],
-	        ["Attributes.Weights.type", "Numerical type of each Weights number" , "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Computation.MACs", "Total number of MAC units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for Linear engine", "string"]	
-	    ]
-	},
-	{
-	    "name" : "torch.aten.maximum",
-	    "properties" : [
-		["Computation.Max", "Total number of Max units in engine", "long"],
-		["Storage.Bytes",   "Total storage required for Max engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "torch.aten.mm",
-	    "properties" : [
-		["Computation.*", "Total number of * units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Mul engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "torch.aten.mul",
-	    "properties" : [
-		["Computation.*", "Total number of * units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Mul engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.mul.Tensor",
-	    "properties" : [
-		["Computation.*", "Total number of * units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Mul engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.constant_pad_nd",
-	    "properties" : [
-		["Attributes.padding", "Value of padding", "string"]
-		]
-	},
-	{
-	    "name" : "torch.aten.add_.Tensor",
-	    "properties" : [
-		["Computation.+", "Total number of + units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Add engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.add.Tensor",
-	    "properties" : [
-		["Attributes.Other.Tensor", "Dimensions of second tensor", "string"],
-		["Attributes.Other.type", "Numerical type of each Tensor element", "string"],
-		["Attributes.Other.Bytes", "Size of second tensor in bytes", "long"],		
-		["Computation.+", "Total number of + units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Add engine", "long"]		
-	    ]
-	},	
-	{
-	    "name" : "torch.aten.minimum",
-	    "properties" : [
-		["Computation.Min", "Total number of Min units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Min engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "aten.div",
-	    "properties" : [
-		["Computation./", "Total number of Div units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Div engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.exp",
-	    "properties" : [
-		["Computation.Exp", "Total number of Exp units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Exp engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "aten.floor",
-	    "properties" : [
-		["Computation.Max", "Total number of Max units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Floor engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.abs",
-	    "properties" : [
-		["Computation.Max", "Total units of Max units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Abs engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.log",
-	    "properties" : [
-		["Computation.log", "Total number of Log units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Log engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.sqrt",
-	    "properties" : [
-		["Computation.sqrt", "Total number of Sqrt units in engine", "long"],
-		["Storage.Bytes", "Total storage required for Log engine", "long"]		
-	    ]
-	},	
-	{
-	    "name" : "torch.aten.neg",
-	    "properties" : [
-		["Storage.Bytes", "Total storage required for Neg engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.sigmoid",
-	    "properties" : [
-		["Storage.Bytes", "Total storage required for Sigmoid engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.mean.dim",
-	    "properties" : [
-		["Storage.Bytes", "Total storage required for Mean engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.gather",
-	    "properties" : [
-		["Attributes.Index.Tensor", "Dimensions of index", "string"],
-		["Attributes.Index.type", "Numerical type of each Index number", "string"],
-		["Attributes.Index.Bytes", "Size of index in bytes", "long"],
-		["Attributes.dim", "Value of dimension", "long"],		
-		["Storage.Bytes", "Total storage required for Gather engine", "long"]		
-	    ]
-	},
-	{
-	    "name" : "torch.aten.slice.Tensor",
-	    "properties" : [
-		["Attributes.Index.Tensor", "Dimensions of index", "string"],
-		["Attributes.Index.type", "Numerical type of each Index number", "string"],
-		["Attributes.Index.Bytes", "Size of index in bytes", "long"],
-		["Attributes.dim", "Value of dimension", "long"],		
-		["Storage.Bytes", "Total storage required for Slicer engine", "long"]		
-	    ]
-	},		
-	{
-	    "name" : "xten.conv2d",
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for this engine", "string"] 
-	    ]
-	},
-	{ 
-	    "name" : "xten.conv2d_bn_relu",
-	    "fused" : ["aten.convolution", "aten.batch_norm", "aten.relu"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    		
-		["Attributes.Mean.Tensor", "Dimensions of mean", "string"],
-		["Attributes.Mean.type", "Numerical type of each Means number", "string"],
-		["Attributes.Mean.Byes", "Size of mean in bytes", "string"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for this engine", "string"]		
-	    ]
-	}, 
-	{
-	    "name" : "xten.conv2d_relu",
-	    "fused" : ["aten.convolution", "aten.relu"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    		
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for this engine", "long"]  		
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_lrelu",
-	    "fused" : ["aten.convolution"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.Alpha.Tensor", "Dimensions of alpha", "string"],
-		["Attributes.Alpha.type", "Numerical type of each alpha number", "string"],
-		["Attributes.Alpha.Bytes", "Size of alpha in bytes", "long"],
-		["Attributes.Alpha", "Value of alpha", "long"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.>", "Total number of > comparator units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for this engine", "long"]  	
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_tensoradd_relu",
-	    "fused" : ["aten.convolution", "torch.aten.add.Tensor", "aten.relu"],
-	    "properties" : [
-		["Attributes.Other.Tensor", "Dimensions of second tensor", "string"],
-		["Attributes.Other.type", "Numerical type of each Tensor element", "string"],
-		["Attributes.Other.Bytes", "Size of second tensor in bytes", "long"],		
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    		
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for this engine", "long"]  		
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_lrelu_maxpool",
-	    "fused" : ["aten.convolution", "aten.max_pool2d"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    					
-		["Attributes.Alpha.Tensor", "Dimensions of alpha", "string"],
-		["Attributes.Alpha.type", "Numerical type of each alpha number", "string"],
-		["Attributes.Alpha.Bytes", "Size of alpha in bytes", "long"],
-		["Attributes.Alpha", "Value of alpha", "long"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for this engine", "long"]  	
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_relu_maxpool",
-	    "fused" : ["aten.convolution", "aten.max_pool2d"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],
-		["Attributes.padding", "Value of padding", "string"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for this engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_lrelu_pad",
-	    "fused" : ["aten.convolution", "torch.aten.constant_pad_nd"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    					
-		["Attributes.Alpha.Tensor", "Dimensions of alpha", "string"],
-		["Attributes.Alpha.type", "Numerical type of each alpha number", "string"],
-		["Attributes.Alpha.Bytes", "Size of alpha in bytes", "long"],
-		["Attributes.Alpha", "Value of alpha", "long"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for this engine", "long"]  	
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_lrelu_pad_maxpool",
-	    "fused" : ["aten.convolution", "torch.aten.constant_pad_nd", "aten.max_pool2d"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],		
-		["Attributes.padding", "Value of padding", "string"],    					
-		["Attributes.Alpha.Tensor", "Dimensions of alpha", "string"],
-		["Attributes.Alpha.type", "Numerical type of each alpha number", "string"],
-		["Attributes.Alpha.Bytes", "Size of alpha in bytes", "long"],
-		["Attributes.Alpha", "Value of alpha", "long"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for this engine", "long"]  	
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_relu_pad_maxpool",
-	    "fused" : ["aten.convolution", "torch.aten.constant_pad_nd", "aten.max_pool2d"],
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights", "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number", "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Attributes.kernel shape", "Dimensions of kernel/filter", "string"],
-		["Attributes.dilation", "Value of dilation", "string"],
-		["Attributes.stride", "Value of strides", "string"],
-		["Attributes.padding", "Value of padding", "string"],
-		["Computation.MACs", "Total units of MAC units in engine", "long"],
-		["Computation.Comparison", "Total number of > comparator units in engine", "long"],
-		["Storage.Bytes", "Total storage required for this engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "xten.add",
-	    "properties" : [
-		["Storage.Bytes", "Total storage required for Add engine", "long"]  	 
-	    ]
-	},
-	{
-	    "name" : "xten.mm",
-	    "properties" : [
-		["Storage.Bytes", "Total storage required for matmul engine", "long"]
-	    ]
-	},
-	{
-	    "name" : "xten.globalaveragepool2d",
-	    "properties" : []
-	},
-	{
-	    "name" : "xten.linear",
-	    "properties" : [
-		["Attributes.Weights.Tensor", "Dimensions of weights" , "string"],
-		["Attributes.Weights.type", "Numerical type of each Weights number" , "string"],
-		["Attributes.Weights.Bytes", "Size of weights in bytes", "long"],
-		["Attributes.Bias.Tensor", "Dimensions of bias", "string"],
-		["Attributes.Bias.type", "Numerical type of each Bias number", "string"],
-		["Attributes.Bias.Bytes", "Size of bias in bytes", "long"],
-		["Computation.MACs", "Total number of MAC units in engine", "long"],		
-		["Storage.Bytes", "Total storage required for Linear engine", "string"]	
-	    ]
-	},
-	{
-	    "name" : "xten.conv2d_tensoradd_globalaveragepool",
-	    "properties" : []
-	},
-	{
-	    "name" : "xten.conv2d_tensoradd_relu_globalaveragepool",
-	    "properties" : []
-	},
-	{
-	    "name" : "xten.conv2d_tensoradd_lrelu_globalaveragepool",
-	    "properties" : []
-	}
-    ]    
+	"ops": [
+		{
+			"name": "torch.aten.convolution",
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total number of MAC units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Convolution engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.max_pool2d",
+			"properties": [
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.Vec Max",
+					"Total number of Vec-Max units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for MaxPool2D engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.mean.dim",
+			"properties": [
+				[
+					"Attributes.dim",
+					"List of dimensions to reduce",
+					"string"
+				],
+				[
+					"Attributes.keepdim",
+					"If true, the mean dimensions are kept",
+					"string"
+				],
+				[
+					"Computation.Vec Max",
+					"Total number of Vec-Max units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Mean engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.squeeze.dim",
+			"properties": [
+				[
+					"Attributes.dim",
+					"The dimension of size 1 to remove",
+					"int"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Squeeze engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.leaky_relu",
+			"properties": [
+				[
+					"Attributes.Alpha.Tensor",
+					"Dimensions of alpha",
+					"string"
+				],
+				[
+					"Attributes.Alpha.type",
+					"Numerical type of each alpha number",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Bytes",
+					"Size of alpha in bytes",
+					"long"
+				],
+				[
+					"Attributes.Alpha",
+					"Value of alpha",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for LReLU engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.relu",
+			"properties": [
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for ReLU engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.batch_norm",
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.Mean.Tensor",
+					"Dimensions of mean",
+					"string"
+				],
+				[
+					"Attributes.Mean.type",
+					"Numerical type of each Means number",
+					"string"
+				],
+				[
+					"Attributes.Mean.Byes",
+					"Size of mean in bytes",
+					"string"
+				],
+				[
+					"Attributes.Variance.Tensor",
+					"Dimensions of variance",
+					"string"
+				],
+				[
+					"Attributes.Variance.type",
+					"Numerical type of each Variances number",
+					"string"
+				],
+				[
+					"Attributes.Variance.Byes",
+					"Size of variance in bytes",
+					"string"
+				],
+				[
+					"Attributes.momentum",
+					"Value of momentum",
+					"long"
+				],
+				[
+					"Attributes.eps",
+					"Value of epsilon",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for NativeBatchNorm engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.adaptive_avg_pool2d",
+			"properties": [
+				[
+					"Attributes.output shape",
+					"Dimensions of output",
+					"string"
+				],
+				[
+					"Computation.+",
+					"Total number of + (addition) units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Adaptive Average Pool engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.size_",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Size engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.cat",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Cat engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.addmm",
+			"properties": [
+				[
+					"Attributes.Mat1.Tensor",
+					"",
+					"string"
+				],
+				[
+					"Attributes.Mat1.type",
+					"",
+					"string"
+				],
+				[
+					"Attributes.Mat1.Bytes",
+					"",
+					"long"
+				],
+				[
+					"Attributes.Mat2.Tensor",
+					"",
+					"string"
+				],
+				[
+					"Attributes.Mat2.type",
+					"",
+					"string"
+				],
+				[
+					"Attributes.Mat2.Bytes",
+					"",
+					"long"
+				],
+				[
+					"Attributes.alpha",
+					"Value of alpha",
+					"long"
+				],
+				[
+					"Attributes.beta",
+					"Value of beta",
+					"long"
+				],
+				[
+					"Computation.+",
+					"Total number of + (addition) units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for AddMM engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.softmax",
+			"properties": [
+				[
+					"Attributes.dim",
+					"Value of dimension along which Softmax is computed",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Softmax engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "torch.aten._softmax",
+			"properties": [
+				[
+					"Attributes.dim",
+					"Value of dimension along which Softmax is computed",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Softmax engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.log_softmax",
+			"properties": [
+				[
+					"Attributes.dim",
+					"Value of dimension along which Softmax is computed",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for LogSoftmax engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.flatten.using_ints",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Flatten engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.linear",
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Computation.MACs",
+					"Total number of MAC units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Linear engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.maximum",
+			"properties": [
+				[
+					"Computation.Max",
+					"Total number of Max units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Max engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.mm",
+			"properties": [
+				[
+					"Computation.*",
+					"Total number of * units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Mul engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.mul",
+			"properties": [
+				[
+					"Computation.*",
+					"Total number of * units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Mul engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.mul.Tensor",
+			"properties": [
+				[
+					"Computation.*",
+					"Total number of * units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Mul engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.constant_pad_nd",
+			"properties": [
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.add_.Tensor",
+			"properties": [
+				[
+					"Computation.+",
+					"Total number of + units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Add engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.add.Tensor",
+			"properties": [
+				[
+					"Attributes.Other.Tensor",
+					"Dimensions of second tensor",
+					"string"
+				],
+				[
+					"Attributes.Other.type",
+					"Numerical type of each Tensor element",
+					"string"
+				],
+				[
+					"Attributes.Other.Bytes",
+					"Size of second tensor in bytes",
+					"long"
+				],
+				[
+					"Computation.+",
+					"Total number of + units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Add engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.minimum",
+			"properties": [
+				[
+					"Computation.Min",
+					"Total number of Min units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Min engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "aten.div",
+			"properties": [
+				[
+					"Computation./",
+					"Total number of Div units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Div engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.exp",
+			"properties": [
+				[
+					"Computation.Exp",
+					"Total number of Exp units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Exp engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "aten.floor",
+			"properties": [
+				[
+					"Computation.Max",
+					"Total number of Max units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Floor engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.abs",
+			"properties": [
+				[
+					"Computation.Max",
+					"Total units of Max units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Abs engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.log",
+			"properties": [
+				[
+					"Computation.log",
+					"Total number of Log units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Log engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.sqrt",
+			"properties": [
+				[
+					"Computation.sqrt",
+					"Total number of Sqrt units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Log engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.neg",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Neg engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.sigmoid",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Sigmoid engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.mean.dim",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Mean engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.gather",
+			"properties": [
+				[
+					"Attributes.Index.Tensor",
+					"Dimensions of index",
+					"string"
+				],
+				[
+					"Attributes.Index.type",
+					"Numerical type of each Index number",
+					"string"
+				],
+				[
+					"Attributes.Index.Bytes",
+					"Size of index in bytes",
+					"long"
+				],
+				[
+					"Attributes.dim",
+					"Value of dimension",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Gather engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "torch.aten.slice.Tensor",
+			"properties": [
+				[
+					"Attributes.Index.Tensor",
+					"Dimensions of index",
+					"string"
+				],
+				[
+					"Attributes.Index.type",
+					"Numerical type of each Index number",
+					"string"
+				],
+				[
+					"Attributes.Index.Bytes",
+					"Size of index in bytes",
+					"long"
+				],
+				[
+					"Attributes.dim",
+					"Value of dimension",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Slicer engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d",
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_bn_relu",
+			"fused": [
+				"aten.convolution",
+				"aten.batch_norm",
+				"aten.relu"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Attributes.Mean.Tensor",
+					"Dimensions of mean",
+					"string"
+				],
+				[
+					"Attributes.Mean.type",
+					"Numerical type of each Means number",
+					"string"
+				],
+				[
+					"Attributes.Mean.Byes",
+					"Size of mean in bytes",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_relu",
+			"fused": [
+				"aten.convolution",
+				"aten.relu"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_lrelu",
+			"fused": [
+				"aten.convolution"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.Alpha.Tensor",
+					"Dimensions of alpha",
+					"string"
+				],
+				[
+					"Attributes.Alpha.type",
+					"Numerical type of each alpha number",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Bytes",
+					"Size of alpha in bytes",
+					"long"
+				],
+				[
+					"Attributes.Alpha",
+					"Value of alpha",
+					"long"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.>",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_tensoradd_relu",
+			"fused": [
+				"aten.convolution",
+				"torch.aten.add.Tensor",
+				"aten.relu"
+			],
+			"properties": [
+				[
+					"Attributes.Other.Tensor",
+					"Dimensions of second tensor",
+					"string"
+				],
+				[
+					"Attributes.Other.type",
+					"Numerical type of each Tensor element",
+					"string"
+				],
+				[
+					"Attributes.Other.Bytes",
+					"Size of second tensor in bytes",
+					"long"
+				],
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_lrelu_maxpool",
+			"fused": [
+				"aten.convolution",
+				"aten.max_pool2d"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Tensor",
+					"Dimensions of alpha",
+					"string"
+				],
+				[
+					"Attributes.Alpha.type",
+					"Numerical type of each alpha number",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Bytes",
+					"Size of alpha in bytes",
+					"long"
+				],
+				[
+					"Attributes.Alpha",
+					"Value of alpha",
+					"long"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_relu_maxpool",
+			"fused": [
+				"aten.convolution",
+				"aten.max_pool2d"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_lrelu_pad",
+			"fused": [
+				"aten.convolution",
+				"torch.aten.constant_pad_nd"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Tensor",
+					"Dimensions of alpha",
+					"string"
+				],
+				[
+					"Attributes.Alpha.type",
+					"Numerical type of each alpha number",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Bytes",
+					"Size of alpha in bytes",
+					"long"
+				],
+				[
+					"Attributes.Alpha",
+					"Value of alpha",
+					"long"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_lrelu_pad_maxpool",
+			"fused": [
+				"aten.convolution",
+				"torch.aten.constant_pad_nd",
+				"aten.max_pool2d"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Tensor",
+					"Dimensions of alpha",
+					"string"
+				],
+				[
+					"Attributes.Alpha.type",
+					"Numerical type of each alpha number",
+					"string"
+				],
+				[
+					"Attributes.Alpha.Bytes",
+					"Size of alpha in bytes",
+					"long"
+				],
+				[
+					"Attributes.Alpha",
+					"Value of alpha",
+					"long"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_relu_pad_maxpool",
+			"fused": [
+				"aten.convolution",
+				"torch.aten.constant_pad_nd",
+				"aten.max_pool2d"
+			],
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Attributes.kernel shape",
+					"Dimensions of kernel/filter",
+					"string"
+				],
+				[
+					"Attributes.dilation",
+					"Value of dilation",
+					"string"
+				],
+				[
+					"Attributes.stride",
+					"Value of strides",
+					"string"
+				],
+				[
+					"Attributes.padding",
+					"Value of padding",
+					"string"
+				],
+				[
+					"Computation.MACs",
+					"Total units of MAC units in engine",
+					"long"
+				],
+				[
+					"Computation.Comparison",
+					"Total number of > comparator units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for this engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.add",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for Add engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.mm",
+			"properties": [
+				[
+					"Storage.Bytes",
+					"Total storage required for matmul engine",
+					"long"
+				]
+			]
+		},
+		{
+			"name": "xten.globalaveragepool2d",
+			"properties": []
+		},
+		{
+			"name": "xten.linear",
+			"properties": [
+				[
+					"Attributes.Weights.Tensor",
+					"Dimensions of weights",
+					"string"
+				],
+				[
+					"Attributes.Weights.type",
+					"Numerical type of each Weights number",
+					"string"
+				],
+				[
+					"Attributes.Weights.Bytes",
+					"Size of weights in bytes",
+					"long"
+				],
+				[
+					"Attributes.Bias.Tensor",
+					"Dimensions of bias",
+					"string"
+				],
+				[
+					"Attributes.Bias.type",
+					"Numerical type of each Bias number",
+					"string"
+				],
+				[
+					"Attributes.Bias.Bytes",
+					"Size of bias in bytes",
+					"long"
+				],
+				[
+					"Computation.MACs",
+					"Total number of MAC units in engine",
+					"long"
+				],
+				[
+					"Storage.Bytes",
+					"Total storage required for Linear engine",
+					"string"
+				]
+			]
+		},
+		{
+			"name": "xten.conv2d_tensoradd_globalaveragepool",
+			"properties": []
+		},
+		{
+			"name": "xten.conv2d_tensoradd_relu_globalaveragepool",
+			"properties": []
+		},
+		{
+			"name": "xten.conv2d_tensoradd_lrelu_globalaveragepool",
+			"properties": []
+		}
+	]
 }

--- a/lib/Transform/operators_supported.json
+++ b/lib/Transform/operators_supported.json
@@ -6,32 +6,38 @@
 				[
 					"Attributes.Weights.Tensor",
 					"Dimensions of weights",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Weights.type",
 					"Numerical type of each Weights number",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Weights.Bytes",
 					"Size of weights in bytes",
-					"long"
+					"long",
+					"operand(1)"
 				],
 				[
 					"Attributes.Bias.Tensor",
 					"Dimensions of bias",
-					"string"
+					"string",
+					"operand(2)"
 				],
 				[
 					"Attributes.Bias.type",
 					"Numerical type of each Bias number",
-					"string"
+					"string",
+					"operand(2)"
 				],
 				[
 					"Attributes.Bias.Bytes",
 					"Size of bias in bytes",
-					"long"
+					"long",
+					"operand(2)"
 				],
 				[
 					"Attributes.kernel shape",
@@ -191,62 +197,74 @@
 				[
 					"Attributes.Weights.Tensor",
 					"Dimensions of weights",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Weights.type",
 					"Numerical type of each Weights number",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Weights.Bytes",
 					"Size of weights in bytes",
-					"long"
+					"long",
+					"operand(1)"
 				],
 				[
 					"Attributes.Bias.Tensor",
 					"Dimensions of bias",
-					"string"
+					"string",
+					"operand(2)"
 				],
 				[
 					"Attributes.Bias.type",
 					"Numerical type of each Bias number",
-					"string"
+					"string",
+					"operand(2)"
 				],
 				[
 					"Attributes.Bias.Bytes",
 					"Size of bias in bytes",
-					"long"
+					"long",
+					"operand(2)"
 				],
 				[
 					"Attributes.Mean.Tensor",
 					"Dimensions of mean",
-					"string"
+					"string",
+					"operand(3)"
 				],
 				[
 					"Attributes.Mean.type",
 					"Numerical type of each Means number",
-					"string"
+					"string",
+					"operand(3)"
 				],
 				[
-					"Attributes.Mean.Byes",
+					"Attributes.Mean.Bytes",
 					"Size of mean in bytes",
-					"string"
+					"string",
+					"operand(3)"
 				],
 				[
 					"Attributes.Variance.Tensor",
 					"Dimensions of variance",
-					"string"
+					"string",
+					"operand(4)"
 				],
 				[
 					"Attributes.Variance.type",
 					"Numerical type of each Variances number",
-					"string"
+					"string",
+					"operand(4)"
 				],
 				[
-					"Attributes.Variance.Byes",
+					"Attributes.Variance.Bytes",
 					"Size of variance in bytes",
-					"string"
+					"string",
+					"operand(4)"
 				],
 				[
 					"Attributes.momentum",
@@ -421,32 +439,38 @@
 				[
 					"Attributes.Weights.Tensor",
 					"Dimensions of weights",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Weights.type",
 					"Numerical type of each Weights number",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Weights.Bytes",
 					"Size of weights in bytes",
-					"long"
+					"long",
+					"operand(1)"
 				],
 				[
 					"Attributes.Bias.Tensor",
 					"Dimensions of bias",
-					"string"
+					"string",
+					"operand(2)"
 				],
 				[
 					"Attributes.Bias.type",
 					"Numerical type of each Bias number",
-					"string"
+					"string",
+					"operand(2)"
 				],
 				[
 					"Attributes.Bias.Bytes",
 					"Size of bias in bytes",
-					"long"
+					"long",
+					"operand(2)"
 				],
 				[
 					"Computation.MACs",
@@ -551,17 +575,20 @@
 				[
 					"Attributes.Other.Tensor",
 					"Dimensions of second tensor",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Other.type",
 					"Numerical type of each Tensor element",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Other.Bytes",
 					"Size of second tensor in bytes",
-					"long"
+					"long",
+					"operand(1)"
 				],
 				[
 					"Computation.+",
@@ -716,17 +743,20 @@
 				[
 					"Attributes.Index.Tensor",
 					"Dimensions of index",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Index.type",
 					"Numerical type of each Index number",
-					"string"
+					"string",
+					"operand(1)"
 				],
 				[
 					"Attributes.Index.Bytes",
 					"Size of index in bytes",
-					"long"
+					"long",
+					"operand(1)"
 				],
 				[
 					"Attributes.dim",


### PR DESCRIPTION
Add the notion that an attribute of an operator corresponds to a specific operand.

This can be specified by appending to the list of operator attributes with the following:
```
operand(x)
```
where `x` is an integer value corresponding to the index location of that attribute in the operand list of the operation.

For example:
```
[
	"Attributes.Weights.Tensor",
	"Dimensions of weights",
	"string",
	"operand(1)"
],
```
The following property above describes the shape of a weights tensor and this corresponds to operand 1 of the operation. This allows us to be more generic in describing our attributes and simplifies our graph generation.