### PR TITLE
feat(mlir-xten): bump to llvm commit '47f67853ac0022389154911c64c3319a394b2969'

### DIFF
--- a/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
+++ b/lib/Dialect/XTen/IR/XTenOpWrapper.cpp
@@ -20,1100 +20,1056 @@
 using namespace mlir::torch;
 
 namespace xilinx {
-    namespace xten {
+namespace xten {
 
-        AbsOpWrapper::~AbsOpWrapper() {}
+AbsOpWrapper::~AbsOpWrapper() {}
 
-        Conv2dOpWrapper::Conv2dOpWrapper(Conv2dOp c) {
-            conv = c;
-        }
-
-        Conv2dOpWrapper::~Conv2dOpWrapper() {}
-
-        Operation* Conv2dOpWrapper::getUnderlyingOperation() {
-            return conv.getOperation();
-        }
-
-        Value Conv2dOpWrapper::getWeights() {
-            return this->conv.getWeight();
-        }
-
-        ArrayRef<Value> Conv2dOpWrapper::getBN() {
-            return ArrayRef<Value>();
-        }
-
-        Optional<Value> Conv2dOpWrapper::getBiases() {
-            return this->conv.getBias();
-        }
-
-        Value Conv2dOpWrapper::getInput() {
-            return this->conv.getInput();
-        }
-
-        Value Conv2dOpWrapper::getPartialInput() {
-            return Value();
-        }
-
-        unsigned int Conv2dOpWrapper::getF0() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
-        }
-
-        unsigned int Conv2dOpWrapper::getF1() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
-        }
-
-        unsigned int Conv2dOpWrapper::getStride() {
-            Value s = this->conv.getStride();
-            SmallVector<int64_t, 2> stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-
-            return stride[0];
-        }
-
-
-        bool Conv2dOpWrapper::hasWeights() {
-            return true;
-        }
-
-        bool Conv2dOpWrapper::hasBias() {
-            return this->getBiases().has_value();
-        }
-
-        bool Conv2dOpWrapper::hasBN() {
-            return false;
-        }
-
-        bool Conv2dOpWrapper::isDepthWise() {
-          llvm::APInt intT = this->conv.getGroups().getDefiningOp<mlir::torch::Torch::ConstantIntOp>().value();
-          uint64_t groups = intT.getSExtValue();
-
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
-            ArrayRef<int64_t> aShapeAR = aShape.getSizes();
-
-            uint64_t C = aShapeAR[C_LOC];
-
-            return groups == C;
-        }
-
-        double Conv2dOpWrapper::getKernelEfficiency() {
-            if(this->isDepthWise()) {
-                return 0.30;
-            } else {
-                return 0.90;
-            }
-        }
-
-        Operation* Conv2dOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
-                                            llvm::Optional<Value> bias, llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                                            llvm::Optional<ArrayRef<Value>> bn) {
-            assert(weight.has_value());
-
-            if(this->hasBias()) {
-                assert(bias.has_value());
-            }
-
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
-
-            Operation* op = this->getUnderlyingOperation();
-            if(firstInPartialChain || partialIn.has_value()) {
-                Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
-                Operation* nOp =  builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
-                                                                  returnType,
-                                                                  input,
-                                                                  chainIn,
-                                                                  weight.value(),
-                                                                  biasVal,
-                                                                  this->conv.getStride(),
-                                                                  this->conv.getPadding(),
-                                                                  this->conv.getDilation(),
-                                                                  this->conv.getGroups());
-
-                nOp->setAttrs(op->getAttrs());
-
-                return nOp;
-            } else {
-                Operation* nOp = builder.create<Conv2dOp>(builder.getUnknownLoc(),
-                                                          returnType,
-                                                          input,
-                                                          weight.value(),
-                                                          biasVal,
-                                                          this->conv.getStride(),
-                                                          this->conv.getPadding(),
-                                                          this->conv.getDilation(),
-                                                          this->conv.getGroups());
-
-                nOp->setAttrs(op->getAttrs());
-
-                return nOp;
-            }
-        }
-
-        Operation* Conv2dOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
-            Operation* op;
-
-            if(resTypes.has_value()) {
-                op =  builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
-                                                      resTypes.value(),
-                                                      this->getInput(),
-                                                      nullptr,
-                                                      this->getWeights(),
-                                                      this->getBiases().value_or(nullptr),
-                                                      this->conv.getStride(),
-                                                      this->conv.getPadding(),
-                                                      this->conv.getDilation(),
-                                                      this->conv.getGroups());
-
-            } else {
-                op = builder.create<Conv2dOp>(builder.getUnknownLoc(),
-                                              this->getUnderlyingOperation()->getResultTypes(),
-                                              this->getInput(),
-                                              this->getWeights(),
-                                              this->getBiases().value_or(nullptr),
-                                              this->conv.getStride(),
-                                              this->conv.getPadding(),
-                                              this->conv.getDilation(),
-                                              this->conv.getGroups());
-            }
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-        PartialConv2dOpWrapper::PartialConv2dOpWrapper(PartialConv2dOp c) {
-            conv = c;
-        }
-
-        PartialConv2dOpWrapper::~PartialConv2dOpWrapper() {}
-
-        Operation* PartialConv2dOpWrapper::getUnderlyingOperation() {
-            return conv.getOperation();
-        }
-
-        Value PartialConv2dOpWrapper::getWeights() {
-            return this->conv.getWeight();
-        }
-
-        ArrayRef<Value> PartialConv2dOpWrapper::getBN() {
-            return ArrayRef<Value>();
-        }
-
-        Optional<Value> PartialConv2dOpWrapper::getBiases() {
-            return this->conv.getBias();
-        }
-
-        Value PartialConv2dOpWrapper::getInput() {
-            return this->conv.getInput();
-        }
-
-        Value PartialConv2dOpWrapper::getPartialInput() {
-            return this->conv.getPartialIn();
-        }
-
-        unsigned int PartialConv2dOpWrapper::getF0() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
-        }
-
-        unsigned int PartialConv2dOpWrapper::getF1() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
-        }
-
-        unsigned int PartialConv2dOpWrapper::getStride() {
-            Value s = this->conv.getStride();
-            SmallVector<int64_t, 2> stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-            return stride[0];
-        }
-
-        bool PartialConv2dOpWrapper::hasWeights() {
-            return true;
-        }
-
-        bool PartialConv2dOpWrapper::hasBias() {
-            return this->getBiases().has_value();
-        }
-
-        bool PartialConv2dOpWrapper::hasBN() {
-            return false;
-        }
-
-        bool PartialConv2dOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
-            ArrayRef<int64_t> aShapeAR = aShape.getSizes();
-
-            int64_t C = aShapeAR[C_LOC];
-
-            return groups == C;
-        }
-
-        double PartialConv2dOpWrapper::getKernelEfficiency() {
-            if(this->isDepthWise()) {
-                return 0.30;
-            } else {
-                return 0.90;
-            }
-        }
-
-        Operation* PartialConv2dOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
-                                                   llvm::Optional<Value> bias, llvm::Optional<Value> partialIn,
-                                                   bool firstInPartialChain, llvm::Optional<ArrayRef<Value>> bn) {
-            assert(weight.has_value());
-            if(this->hasBias()) {
-                assert(bias.has_value());
-            }
-
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
-
-            Value chainIn;
-            if(partialIn.has_value()) {
-                chainIn = partialIn.value();
-            } else if(this->conv.getPartialIn()){
-                chainIn = this->conv.getPartialIn();
-            } else {
-                chainIn = Value();
-            }
-
-            Operation* op = this->getUnderlyingOperation();
-
-            Operation* nOp =  builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
-                                                              returnType,
-                                                              input,
-                                                              chainIn,
-                                                              weight.value(),
-                                                              biasVal,
-                                                              this->conv.getStride(),
-                                                              this->conv.getPadding(),
-                                                              this->conv.getDilation(),
-                                                              this->conv.getGroups());
-
-            nOp->setAttrs(op->getAttrs());
-            return nOp;
-        }
-
-        Operation* PartialConv2dOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
-            Operation* op;
-
-            if(resTypes.has_value()) {
-                op = builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
-                                                     resTypes.value(),
-                                                     this->getInput(),
-                                                     this->conv.getPartialIn(),
-                                                     this->getWeights(),
-                                                     this->getBiases().value_or(nullptr),
-                                                     this->conv.getStride(),
-                                                     this->conv.getPadding(),
-                                                     this->conv.getDilation(),
-                                                     this->conv.getGroups());
-            } else {
-                op = builder.create<PartialConv2dOp>(builder.getUnknownLoc(),
-                                                     this->getUnderlyingOperation()->getResultTypes(),
-                                                     this->getInput(),
-                                                     this->conv.getPartialIn(),
-                                                     this->getWeights(),
-                                                     this->getBiases().value_or(nullptr),
-                                                     this->conv.getStride(),
-                                                     this->conv.getPadding(),
-                                                     this->conv.getDilation(),
-                                                     this->conv.getGroups());
-            }
-
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-        Conv2dReLUOpWrapper::Conv2dReLUOpWrapper(Conv2dReLUOp c) {
-            conv = c;
-        }
-
-        Conv2dReLUOpWrapper::~Conv2dReLUOpWrapper() {}
-
-        Operation* Conv2dReLUOpWrapper::getUnderlyingOperation() {
-            return conv.getOperation();
-        }
-
-        Value Conv2dReLUOpWrapper::getWeights() {
-            return this->conv.getWeight();
-        }
-
-        ArrayRef<Value> Conv2dReLUOpWrapper::getBN() {
-            return ArrayRef<Value>();
-        }
-
-        Optional<Value> Conv2dReLUOpWrapper::getBiases() {
-            return this->conv.getBias();
-        }
-
-        Value Conv2dReLUOpWrapper::getInput() {
-            return this->conv.getInput();
-        }
-
-        Value Conv2dReLUOpWrapper::getPartialInput() {
-            return Value();
-        }
-
-        unsigned int Conv2dReLUOpWrapper::getF0() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
-        }
-
-        unsigned int Conv2dReLUOpWrapper::getF1() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
-        }
-
-        unsigned int Conv2dReLUOpWrapper::getStride() {
-            Value s = this->conv.getStride();
-            SmallVector<int64_t,2> stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-
-            return stride[0];
-        }
-
-        bool Conv2dReLUOpWrapper::hasWeights() {
-            return true;
-        }
-
-        bool Conv2dReLUOpWrapper::hasBias() {
-            return this->getBiases().has_value();
-        }
-
-        bool Conv2dReLUOpWrapper::hasBN() {
-            return false;
-        }
-
-        bool Conv2dReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
-            ArrayRef<int64_t> aShapeAR = aShape.getSizes();
-
-            int64_t C = aShapeAR[C_LOC];
-
-            return groups == C;
-        }
-
-        double Conv2dReLUOpWrapper::getKernelEfficiency() {
-            if(this->isDepthWise()) {
-                return 0.30;
-            } else {
-                return 0.90;
-            }
-        }
-
-        Operation* Conv2dReLUOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
-                                                llvm::Optional<Value> bias, llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                                                llvm::Optional<ArrayRef<Value>> bn) {
-            assert(weight.has_value());
-
-            if(this->hasBias()) {
-                assert(bias.has_value());
-            }
-
-            Operation* op = this->getUnderlyingOperation();
-            Value biasVal = (bias.has_value()) ? bias.value() : this->conv.getBias();
-
-            if(firstInPartialChain || partialIn.has_value()) {
-                Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
-                Operation* nOp =  builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
-                                                                      returnType,
-                                                                      input,
-                                                                      chainIn,
-                                                                      weight.value(),
-                                                                      biasVal,
-                                                                      this->conv.getStride(),
-                                                                      this->conv.getPadding(),
-                                                                      this->conv.getDilation(),
-                                                                      this->conv.getGroups());
-
-                nOp->setAttrs(op->getAttrs());
-                return nOp;
-            } else {
-                Operation* nOp = builder.create<Conv2dReLUOp>(builder.getUnknownLoc(),
-                                                              returnType,
-                                                              input,
-                                                              weight.value(),
-                                                              biasVal,
-                                                              this->conv.getStride(),
-                                                              this->conv.getPadding(),
-                                                              this->conv.getDilation(),
-                                                              this->conv.getGroups());
-
-                nOp->setAttrs(op->getAttrs());
-                return nOp;
-            }
-        }
-
-        Operation* Conv2dReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
-            Operation* op;
-
-            if(resTypes.has_value()) {
-                op =  builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
-                                                          resTypes.value(),
-                                                          this->getInput(),
-                                                          Value(),
-                                                          this->getWeights(),
-                                                          this->getBiases().value_or(nullptr),
-                                                          this->conv.getStride(),
-                                                          this->conv.getPadding(),
-                                                          this->conv.getDilation(),
-                                                          this->conv.getGroups());
-            } else {
-                op = builder.create<Conv2dReLUOp>(builder.getUnknownLoc(),
-                                                  this->getUnderlyingOperation()->getResultTypes(),
-                                                  this->getInput(),
-                                                  this->getWeights(),
-                                                  this->getBiases().value_or(nullptr),
-                                                  this->conv.getStride(),
-                                                  this->conv.getPadding(),
-                                                  this->conv.getDilation(),
-                                                  this->conv.getGroups());
-            }
-
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-        PartialConv2dReLUOpWrapper::PartialConv2dReLUOpWrapper(PartialConv2dReLUOp c) {
-            conv = c;
-        }
-
-        PartialConv2dReLUOpWrapper::~PartialConv2dReLUOpWrapper() {}
-
-        Operation* PartialConv2dReLUOpWrapper::getUnderlyingOperation() {
-            return conv.getOperation();
-        }
-
-        Value PartialConv2dReLUOpWrapper::getWeights() {
-            return this->conv.getWeight();
-        }
-
-        ArrayRef<Value> PartialConv2dReLUOpWrapper::getBN() {
-            return ArrayRef<Value>();
-        }
-
-        Optional<Value> PartialConv2dReLUOpWrapper::getBiases() {
-            return this->conv.getBias();
-        }
-
-        Value PartialConv2dReLUOpWrapper::getInput() {
-            return this->conv.getInput();
-        }
-
-        Value PartialConv2dReLUOpWrapper::getPartialInput() {
-            return this->conv.getPartialIn();
-        }
-
-        unsigned int PartialConv2dReLUOpWrapper::getF0() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
-        }
-
-        unsigned int PartialConv2dReLUOpWrapper::getF1() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
-        }
-
-        unsigned int PartialConv2dReLUOpWrapper::getStride() {
-            Value s = this->conv.getStride();
-            SmallVector<int64_t,2> stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-
-            return stride[0];
-        }
-
-        bool PartialConv2dReLUOpWrapper::hasWeights() {
-            return true;
-        }
-
-        bool PartialConv2dReLUOpWrapper::hasBias() {
-            return this->getBiases().has_value();
-        }
-
-        bool PartialConv2dReLUOpWrapper::hasBN() {
-            return false;
-        }
-
-        bool PartialConv2dReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
-            ArrayRef<int64_t> aShapeAR = aShape.getSizes();
-
-            int64_t C = aShapeAR[C_LOC];
-
-            return groups == C;
-        }
-
-        double PartialConv2dReLUOpWrapper::getKernelEfficiency() {
-            if(this->isDepthWise()) {
-                return 0.30;
-            } else {
-                return 0.90;
-            }
-        }
-
-        Operation* PartialConv2dReLUOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input,
-                                                       llvm::Optional<Value> weight, llvm::Optional<Value> bias,
-                                                       llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                                                       llvm::Optional<ArrayRef<Value>> bn) {
-            assert(weight.has_value());
-
-            if(this->hasBias()) {
-                assert(bias.has_value());
-            }
-
-            Value chainIn;
-            if(partialIn.has_value()) {
-                chainIn = partialIn.value();
-            } else if(this->conv.getPartialIn()){
-                chainIn = this->conv.getPartialIn();
-            } else {
-                chainIn = Value();
-            }
-
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
-
-            Operation* op = this->getUnderlyingOperation();
-            Operation* nOp = builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
-                                                                 returnType,
-                                                                 input,
-                                                                 chainIn,
-                                                                 weight.value(),
-                                                                 biasVal,
-                                                                 this->conv.getStride(),
-                                                                 this->conv.getPadding(),
-                                                                 this->conv.getDilation(),
-                                                                 this->conv.getGroups());
-            nOp->setAttrs(op->getAttrs());
-            return nOp;
-        }
-
-        Operation* PartialConv2dReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
-            Operation* op;
-
-            if(resTypes.has_value()) {
-                op = builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
-                                                         resTypes.value(),
-                                                         this->getInput(),
-                                                         this->conv.getPartialIn(),
-                                                         this->getWeights(),
-                                                         this->getBiases().value_or(nullptr),
-                                                         this->conv.getStride(),
-                                                         this->conv.getPadding(),
-                                                         this->conv.getDilation(),
-                                                         this->conv.getGroups());
-            } else {
-                op = builder.create<PartialConv2dReLUOp>(builder.getUnknownLoc(),
-                                                         this->getUnderlyingOperation()->getResultTypes(),
-                                                         this->getInput(),
-                                                         this->conv.getPartialIn(),
-                                                         this->getWeights(),
-                                                         this->getBiases().value_or(nullptr),
-                                                         this->conv.getStride(),
-                                                         this->conv.getPadding(),
-                                                         this->conv.getDilation(),
-                                                         this->conv.getGroups());
-            }
-
-
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-        PartialConv2dBatchNormReLUOpWrapper::PartialConv2dBatchNormReLUOpWrapper(PartialConv2dBatchNormReLUOp c) {
-            conv = c;
-        }
-
-        PartialConv2dBatchNormReLUOpWrapper::~PartialConv2dBatchNormReLUOpWrapper() {}
-
-        Operation* PartialConv2dBatchNormReLUOpWrapper::getUnderlyingOperation() {
-            return conv.getOperation();
-        }
-
-        Value PartialConv2dBatchNormReLUOpWrapper::getWeights() {
-            return this->conv.getWeight();
-        }
-
-        ArrayRef<Value> PartialConv2dBatchNormReLUOpWrapper::getBN() {
-            return ArrayRef<Value>({this->conv.getBnWeight(), this->conv.getBnBias(), this->conv.getRunningMean(), this->conv.getRunningVar()});
-        }
-
-        Optional<Value> PartialConv2dBatchNormReLUOpWrapper::getBiases() {
-            return this->conv.getBias();
-        }
-
-        Value PartialConv2dBatchNormReLUOpWrapper::getInput() {
-            return this->conv.getInput();
-        }
-
-        Value PartialConv2dBatchNormReLUOpWrapper::getPartialInput() {
-            return this->conv.getPartialIn();
-        }
-
-        unsigned int PartialConv2dBatchNormReLUOpWrapper::getF0() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
-        }
-
-        unsigned int PartialConv2dBatchNormReLUOpWrapper::getF1() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
-        }
-
-        unsigned int PartialConv2dBatchNormReLUOpWrapper::getStride() {
-            Value s = this->conv.getStride();
-            SmallVector<int64_t,2 > stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-
-            return stride[0];
-        }
-
-        bool PartialConv2dBatchNormReLUOpWrapper::hasWeights() {
-            return true;
-        }
-
-        bool PartialConv2dBatchNormReLUOpWrapper::hasBias() {
-            return this->getBiases().has_value();
-        }
-
-        bool PartialConv2dBatchNormReLUOpWrapper::hasBN() {
-            return true;
-        }
-
-        bool PartialConv2dBatchNormReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
-            ArrayRef<int64_t> aShapeAR = aShape.getSizes();
-
-            int64_t C = aShapeAR[C_LOC];
-
-            return groups == C;
-        }
-
-        double PartialConv2dBatchNormReLUOpWrapper::getKernelEfficiency() {
-            if(this->isDepthWise()) {
-                return 0.30;
-            } else {
-                return 0.90;
-            }
-        }
-
-        Operation* PartialConv2dBatchNormReLUOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input,
-                                                                llvm::Optional<Value> weight, llvm::Optional<Value> bias,
-                                                                llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                                                                llvm::Optional<ArrayRef<Value>> bn) {
-            assert(weight.has_value());
-            assert(bn.has_value());
-
-            if(this->hasBias()) {
-                assert(bias.has_value());
-            }
-
-            Value chainIn;
-            if(partialIn.has_value()) {
-                chainIn = partialIn.value();
-            } else if(this->conv.getPartialIn()){
-                chainIn = this->conv.getPartialIn();
-            } else {
-                chainIn = Value();
-            }
-
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
-
-            Operation* op = this->getUnderlyingOperation();
-            Operation* nOp = builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                                          returnType,
-                                                                          input,
-                                                                          chainIn,
-                                                                          weight.value(),
-                                                                          biasVal,
-                                                                          this->conv.getStride(),
-                                                                          this->conv.getPadding(),
-                                                                          this->conv.getDilation(),
-                                                                          this->conv.getGroups(),
-                                                                          bn.value()[0],
-                                                                          bn.value()[1],
-                                                                          bn.value()[2],
-                                                                          bn.value()[3],
-                                                                          this->conv.getTraining(),
-                                                                          this->conv.getMomentum(),
-                                                                          this->conv.getEps());
-
-            nOp->setAttrs(op->getAttrs());
-            return nOp;
-        }
-
-        Operation* PartialConv2dBatchNormReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
-            Operation* op;
-            if(resTypes.has_value()) {
-                op = builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                                  resTypes.value(),
-                                                                  this->getInput(),
-                                                                  this->conv.getPartialIn(),
-                                                                  this->getWeights(),
-                                                                  this->getBiases().value_or(nullptr),
-                                                                  this->conv.getStride(),
-                                                                  this->conv.getPadding(),
-                                                                  this->conv.getDilation(),
-                                                                  this->conv.getGroups(),
-                                                                  this->conv.getBnWeight(),
-                                                                  this->conv.getBnBias(),
-                                                                  this->conv.getRunningMean(),
-                                                                  this->conv.getRunningVar(),
-                                                                  this->conv.getTraining(),
-                                                                  this->conv.getMomentum(),
-                                                                  this->conv.getEps());
-            } else {
-                op = builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                                  this->getUnderlyingOperation()->getResultTypes(),
-                                                                  this->getInput(),
-                                                                  this->conv.getPartialIn(),
-                                                                  this->getWeights(),
-                                                                  this->getBiases().value_or(nullptr),
-                                                                  this->conv.getStride(),
-                                                                  this->conv.getPadding(),
-                                                                  this->conv.getDilation(),
-                                                                  this->conv.getGroups(),
-                                                                  this->conv.getBnWeight(),
-                                                                  this->conv.getBnBias(),
-                                                                  this->conv.getRunningMean(),
-                                                                  this->conv.getRunningVar(),
-                                                                  this->conv.getTraining(),
-                                                                  this->conv.getMomentum(),
-                                                                  this->conv.getEps());
-            }
-
-
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-
-        Conv2dBatchNormReLUOpWrapper::Conv2dBatchNormReLUOpWrapper(Conv2dBatchNormReLUOp c) {
-            conv = c;
-        }
-
-        Conv2dBatchNormReLUOpWrapper::~Conv2dBatchNormReLUOpWrapper() {}
-
-        Operation* Conv2dBatchNormReLUOpWrapper::getUnderlyingOperation() {
-            return conv.getOperation();
-        }
-
-        Value Conv2dBatchNormReLUOpWrapper::getWeights() {
-            return this->conv.getWeight();
-        }
-
-        ArrayRef<Value> Conv2dBatchNormReLUOpWrapper::getBN() {
-            return ArrayRef<Value>({this->conv.getBnWeight(), this->conv.getBnBias(), this->conv.getRunningMean(), this->conv.getRunningVar()});
-        }
-
-        Optional<Value> Conv2dBatchNormReLUOpWrapper::getBiases() {
-            return this->conv.getBias();
-        }
-
-        Value Conv2dBatchNormReLUOpWrapper::getInput() {
-            return this->conv.getInput();
-        }
-
-        Value Conv2dBatchNormReLUOpWrapper::getPartialInput() {
-            return Value();
-        }
-
-        unsigned int Conv2dBatchNormReLUOpWrapper::getF0() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F0_LOC];
-        }
-
-        unsigned int Conv2dBatchNormReLUOpWrapper::getF1() {
-            return this->conv.getWeight().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>().getSizes()[F1_LOC];
-        }
-
-        unsigned int Conv2dBatchNormReLUOpWrapper::getStride() {
-            Value s = this->conv.getStride();
-            SmallVector<int64_t,2> stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-
-            return stride[0];
-        }
-
-        bool Conv2dBatchNormReLUOpWrapper::hasWeights() {
-            return true;
-        }
-
-        bool Conv2dBatchNormReLUOpWrapper::hasBias() {
-            return this->getBiases().has_value();
-        }
-
-        bool Conv2dBatchNormReLUOpWrapper::hasBN() {
-            return true;
-        }
-
-        bool Conv2dBatchNormReLUOpWrapper::isDepthWise() {
-            unsigned int groups = this->conv.getGroups().getDefiningOp<mlir::arith::ConstantIntOp>().value();
-            mlir::torch::Torch::BaseTensorType aShape = this->conv.getInput().getType().dyn_cast<mlir::torch::Torch::BaseTensorType>();
-            ArrayRef<int64_t> aShapeAR = aShape.getSizes();
-
-            int64_t C = aShapeAR[C_LOC];
-
-            return groups == C;
-        }
-
-        double Conv2dBatchNormReLUOpWrapper::getKernelEfficiency() {
-            if(this->isDepthWise()) {
-                return 0.30;
-            } else {
-                return 0.90;
-            }
-        }
-
-        Operation* Conv2dBatchNormReLUOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input,
-                                                                llvm::Optional<Value> weight, llvm::Optional<Value> bias,
-                                                                llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                                                                llvm::Optional<ArrayRef<Value>> bn) {
-            assert(weight.has_value());
-            assert(bn.has_value());
-
-            if(this->hasBias()) {
-                assert(bias.has_value());
-            }
-
-            Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
-
-            Operation* op = this->getUnderlyingOperation();
-            if(firstInPartialChain || partialIn.has_value()) {
-                Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
-                Operation* nOp =  builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                                               returnType,
-                                                                               input,
-                                                                               chainIn,
-                                                                               weight.value(),
-                                                                               biasVal,
-                                                                               this->conv.getStride(),
-                                                                               this->conv.getPadding(),
-                                                                               this->conv.getDilation(),
-                                                                               this->conv.getGroups(),
-                                                                               bn.value()[0],
-                                                                               bn.value()[1],
-                                                                               bn.value()[2],
-                                                                               bn.value()[3],
-                                                                               this->conv.getTraining(),
-                                                                               this->conv.getMomentum(),
-                                                                               this->conv.getEps());
-                nOp->setAttrs(op->getAttrs());
-
-                return nOp;
-            } else {
-                Operation* nOp = builder.create<Conv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                                       returnType,
-                                                                       input,
-                                                                       weight.value(),
-                                                                       biasVal,
-                                                                       this->conv.getStride(),
-                                                                       this->conv.getPadding(),
-                                                                       this->conv.getDilation(),
-                                                                       this->conv.getGroups(),
-                                                                       bn.value()[0],
-                                                                       bn.value()[1],
-                                                                       bn.value()[2],
-                                                                       bn.value()[3],
-                                                                       this->conv.getTraining(),
-                                                                       this->conv.getMomentum(),
-                                                                       this->conv.getEps());
-
-                nOp->setAttrs(op->getAttrs());
-
-                return nOp;
-            }
-        }
-
-        Operation* Conv2dBatchNormReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
-            Operation* op;
-
-            if(resTypes.has_value()) {
-                op =  builder.create<PartialConv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                                   resTypes.value(),
-                                                                   this->getInput(),
-                                                                   Value(),
-                                                                   this->getWeights(),
-                                                                   this->getBiases().value_or(nullptr),
-                                                                   this->conv.getStride(),
-                                                                   this->conv.getPadding(),
-                                                                   this->conv.getDilation(),
-                                                                   this->conv.getGroups(),
-                                                                   this->conv.getBnWeight(),
-                                                                   this->conv.getBnBias(),
-                                                                   this->conv.getRunningMean(),
-                                                                   this->conv.getRunningVar(),
-                                                                   this->conv.getTraining(),
-                                                                   this->conv.getMomentum(),
-                                                                   this->conv.getEps());
-            } else {
-                op = builder.create<Conv2dBatchNormReLUOp>(builder.getUnknownLoc(),
-                                                           this->getUnderlyingOperation()->getResultTypes(),
-                                                           this->getInput(),
-                                                           this->getWeights(),
-                                                           this->getBiases().value_or(nullptr),
-                                                           this->conv.getStride(),
-                                                           this->conv.getPadding(),
-                                                           this->conv.getDilation(),
-                                                           this->conv.getGroups(),
-                                                           this->conv.getBnWeight(),
-                                                           this->conv.getBnBias(),
-                                                           this->conv.getRunningMean(),
-                                                           this->conv.getRunningVar(),
-                                                           this->conv.getTraining(),
-                                                           this->conv.getMomentum(),
-                                                           this->conv.getEps());
-            }
-
-
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-        MaxPool2dOpWrapper::MaxPool2dOpWrapper(Torch::AtenMaxPool2dOp mp) {
-            maxpool = mp;
-        }
-
-        MaxPool2dOpWrapper::~MaxPool2dOpWrapper() {}
-
-
-        Operation* MaxPool2dOpWrapper::getUnderlyingOperation() {
-            return maxpool.getOperation();
-        }
-
-        Value MaxPool2dOpWrapper::getWeights() {
-            return Value();
-        }
-
-        Optional<Value> MaxPool2dOpWrapper::getBiases() {
-            return Optional<Value>{};
-        }
-
-        unsigned int MaxPool2dOpWrapper::getF0() {
-            Value ks = this->maxpool.kernel_size();
-            SmallVector<int64_t,2> kernel_size;
-            matchPattern(ks, Torch::m_TorchConstantIntList(kernel_size));
-
-            return kernel_size[0];
-        }
-
-        unsigned int MaxPool2dOpWrapper::getF1() {
-            Value ks = this->maxpool.kernel_size();
-            SmallVector<int64_t,2> kernel_size;
-            matchPattern(ks, Torch::m_TorchConstantIntList(kernel_size));
-
-            return kernel_size[1];
-        }
-
-        unsigned int MaxPool2dOpWrapper::getStride() {
-            Value s = this->maxpool.stride();
-            SmallVector<int64_t,2> stride;
-            matchPattern(s, Torch::m_TorchConstantIntList(stride));
-
-            return stride[0];
-        }
-
-        Value MaxPool2dOpWrapper::getInput() {
-            return this->maxpool.self();
-        }
-
-        Value MaxPool2dOpWrapper::getPartialInput() {
-            return Value();
-        }
-
-        ArrayRef<Value> MaxPool2dOpWrapper::getBN() {
-            return ArrayRef<Value>();
-        }
-
-        bool MaxPool2dOpWrapper::hasWeights() {
-            return false;
-        }
-
-        bool MaxPool2dOpWrapper::hasBias() {
-            return false;
-        }
-
-        bool MaxPool2dOpWrapper::isDepthWise() {
-            return true;
-        }
-
-        bool MaxPool2dOpWrapper::hasBN() {
-            return false;
-        }
-
-        double MaxPool2dOpWrapper::getKernelEfficiency() {
-            return 0.25;
-        }
-
-        Operation* MaxPool2dOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType, Value input,
-                                                          llvm::Optional<Value> weight, llvm::Optional<Value> bias,
-                                                          llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                                                          llvm::Optional<ArrayRef<Value>> bn) {
-            assert(!weight.has_value());
-            assert(!bias.has_value());
-            assert(!firstInPartialChain);
-            assert(!partialIn.has_value());
-
-            Operation* op = this->getUnderlyingOperation();
-            Operation* nOp =  builder.create<Torch::AtenMaxPool2dOp>(builder.getUnknownLoc(), returnType, input,
-                                                                     this->maxpool.kernel_size(),
-                                                                     this->maxpool.stride(),
-                                                                     this->maxpool.padding(),
-                                                                     this->maxpool.dilation(),
-                                                                     this->maxpool.ceil_mode());
-
-            nOp->setAttrs(op->getAttrs());
-            return nOp;
-        }
-
-        Operation* MaxPool2dOpWrapper::wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> typeRes) {
-            assert(!typeRes.has_value());
-
-            Operation* op =  builder.create<Torch::AtenMaxPool2dOp>(builder.getUnknownLoc(),
-                                                                    this->getUnderlyingOperation()->getResultTypes(),
-                                                                    this->getInput(),
-                                                                    this->maxpool.kernel_size(),
-                                                                    this->maxpool.stride(),
-                                                                    this->maxpool.padding(),
-                                                                    this->maxpool.dilation(),
-                                                                    this->maxpool.ceil_mode());
-
-            op->setAttrs(this->getUnderlyingOperation()->getAttrs());
-
-            auto ty = IntegerType::get(builder.getContext(), 32);
-            auto attr = IntegerAttr::get(ty, into);
-            op->setAttr(llvm::StringRef("locW"), attr);
-
-            return op;
-        }
-
-    }
+Conv2dOpWrapper::Conv2dOpWrapper(Conv2dOp c) {
+  conv = c;
 }
 
+Conv2dOpWrapper::~Conv2dOpWrapper() {}
+
+Operation *Conv2dOpWrapper::getUnderlyingOperation() {
+  return conv.getOperation();
+}
+
+Value Conv2dOpWrapper::getWeights() {
+  return this->conv.getWeight();
+}
+
+ArrayRef<Value> Conv2dOpWrapper::getBN() {
+  return ArrayRef<Value>();
+}
+
+Optional<Value> Conv2dOpWrapper::getBiases() {
+  return this->conv.getBias();
+}
+
+Value Conv2dOpWrapper::getInput() {
+  return this->conv.getInput();
+}
+
+Value Conv2dOpWrapper::getPartialInput() {
+  return Value();
+}
+
+unsigned int Conv2dOpWrapper::getF0() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F0_LOC];
+}
+
+unsigned int Conv2dOpWrapper::getF1() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F1_LOC];
+}
+
+unsigned int Conv2dOpWrapper::getStride() {
+  Value s = this->conv.getStride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+
+  return stride[0];
+}
+
+bool Conv2dOpWrapper::hasWeights() {
+  return true;
+}
+
+bool Conv2dOpWrapper::hasBias() {
+  return this->getBiases().has_value();
+}
+
+bool Conv2dOpWrapper::hasBN() {
+  return false;
+}
+
+bool Conv2dOpWrapper::isDepthWise() {
+  llvm::APInt intT = this->conv.getGroups()
+                         .getDefiningOp<mlir::torch::Torch::ConstantIntOp>()
+                         .value();
+  uint64_t groups = intT.getSExtValue();
+
+  mlir::torch::Torch::BaseTensorType aShape =
+      this->conv.getInput()
+          .getType()
+          .dyn_cast<mlir::torch::Torch::BaseTensorType>();
+  ArrayRef<int64_t> aShapeAR = aShape.getSizes();
+
+  uint64_t C = aShapeAR[C_LOC];
+
+  return groups == C;
+}
+
+double Conv2dOpWrapper::getKernelEfficiency() {
+  if (this->isDepthWise()) {
+    return 0.30;
+  } else {
+    return 0.90;
+  }
+}
+
+Operation *Conv2dOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType,
+                                    Value input, llvm::Optional<Value> weight,
+                                    llvm::Optional<Value> bias,
+                                    llvm::Optional<Value> partialIn,
+                                    bool firstInPartialChain,
+                                    llvm::Optional<ArrayRef<Value>> bn) {
+  assert(weight.has_value());
+
+  if (this->hasBias()) {
+    assert(bias.has_value());
+  }
+
+  Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
+
+  Operation *op = this->getUnderlyingOperation();
+  if (firstInPartialChain || partialIn.has_value()) {
+    Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
+    Operation *nOp = builder.create<PartialConv2dOp>(
+        builder.getUnknownLoc(), returnType, input, chainIn, weight.value(),
+        biasVal, this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+
+    nOp->setAttrs(op->getAttrs());
+
+    return nOp;
+  } else {
+    Operation *nOp = builder.create<Conv2dOp>(
+        builder.getUnknownLoc(), returnType, input, weight.value(), biasVal,
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+
+    nOp->setAttrs(op->getAttrs());
+
+    return nOp;
+  }
+}
+
+Operation *Conv2dOpWrapper::wCopy(OpBuilder &builder, unsigned int into,
+                                  llvm::Optional<TypeRange> resTypes) {
+  Operation *op;
+
+  if (resTypes.has_value()) {
+    op = builder.create<PartialConv2dOp>(
+        builder.getUnknownLoc(), resTypes.value(), this->getInput(), nullptr,
+        this->getWeights(), this->getBiases().value_or(nullptr),
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+
+  } else {
+    op = builder.create<Conv2dOp>(
+        builder.getUnknownLoc(),
+        this->getUnderlyingOperation()->getResultTypes(), this->getInput(),
+        this->getWeights(), this->getBiases().value_or(nullptr),
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+  }
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+PartialConv2dOpWrapper::PartialConv2dOpWrapper(PartialConv2dOp c) {
+  conv = c;
+}
+
+PartialConv2dOpWrapper::~PartialConv2dOpWrapper() {}
+
+Operation *PartialConv2dOpWrapper::getUnderlyingOperation() {
+  return conv.getOperation();
+}
+
+Value PartialConv2dOpWrapper::getWeights() {
+  return this->conv.getWeight();
+}
+
+ArrayRef<Value> PartialConv2dOpWrapper::getBN() {
+  return ArrayRef<Value>();
+}
+
+Optional<Value> PartialConv2dOpWrapper::getBiases() {
+  return this->conv.getBias();
+}
+
+Value PartialConv2dOpWrapper::getInput() {
+  return this->conv.getInput();
+}
+
+Value PartialConv2dOpWrapper::getPartialInput() {
+  return this->conv.getPartialIn();
+}
+
+unsigned int PartialConv2dOpWrapper::getF0() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F0_LOC];
+}
+
+unsigned int PartialConv2dOpWrapper::getF1() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F1_LOC];
+}
+
+unsigned int PartialConv2dOpWrapper::getStride() {
+  Value s = this->conv.getStride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+  return stride[0];
+}
+
+bool PartialConv2dOpWrapper::hasWeights() {
+  return true;
+}
+
+bool PartialConv2dOpWrapper::hasBias() {
+  return this->getBiases().has_value();
+}
+
+bool PartialConv2dOpWrapper::hasBN() {
+  return false;
+}
+
+bool PartialConv2dOpWrapper::isDepthWise() {
+  unsigned int groups = this->conv.getGroups()
+                            .getDefiningOp<mlir::arith::ConstantIntOp>()
+                            .value();
+  mlir::torch::Torch::BaseTensorType aShape =
+      this->conv.getInput()
+          .getType()
+          .dyn_cast<mlir::torch::Torch::BaseTensorType>();
+  ArrayRef<int64_t> aShapeAR = aShape.getSizes();
+
+  int64_t C = aShapeAR[C_LOC];
+
+  return groups == C;
+}
+
+double PartialConv2dOpWrapper::getKernelEfficiency() {
+  if (this->isDepthWise()) {
+    return 0.30;
+  } else {
+    return 0.90;
+  }
+}
+
+Operation *PartialConv2dOpWrapper::buildOp(OpBuilder &builder,
+                                           TypeRange returnType, Value input,
+                                           llvm::Optional<Value> weight,
+                                           llvm::Optional<Value> bias,
+                                           llvm::Optional<Value> partialIn,
+                                           bool firstInPartialChain,
+                                           llvm::Optional<ArrayRef<Value>> bn) {
+  assert(weight.has_value());
+  if (this->hasBias()) {
+    assert(bias.has_value());
+  }
+
+  Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
+
+  Value chainIn;
+  if (partialIn.has_value()) {
+    chainIn = partialIn.value();
+  } else if (this->conv.getPartialIn()) {
+    chainIn = this->conv.getPartialIn();
+  } else {
+    chainIn = Value();
+  }
+
+  Operation *op = this->getUnderlyingOperation();
+
+  Operation *nOp = builder.create<PartialConv2dOp>(
+      builder.getUnknownLoc(), returnType, input, chainIn, weight.value(),
+      biasVal, this->conv.getStride(), this->conv.getPadding(),
+      this->conv.getDilation(), this->conv.getGroups());
+
+  nOp->setAttrs(op->getAttrs());
+  return nOp;
+}
+
+Operation *PartialConv2dOpWrapper::wCopy(OpBuilder &builder, unsigned int into,
+                                         llvm::Optional<TypeRange> resTypes) {
+  Operation *op;
+
+  if (resTypes.has_value()) {
+    op = builder.create<PartialConv2dOp>(
+        builder.getUnknownLoc(), resTypes.value(), this->getInput(),
+        this->conv.getPartialIn(), this->getWeights(),
+        this->getBiases().value_or(nullptr), this->conv.getStride(),
+        this->conv.getPadding(), this->conv.getDilation(),
+        this->conv.getGroups());
+  } else {
+    op = builder.create<PartialConv2dOp>(
+        builder.getUnknownLoc(),
+        this->getUnderlyingOperation()->getResultTypes(), this->getInput(),
+        this->conv.getPartialIn(), this->getWeights(),
+        this->getBiases().value_or(nullptr), this->conv.getStride(),
+        this->conv.getPadding(), this->conv.getDilation(),
+        this->conv.getGroups());
+  }
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+Conv2dReLUOpWrapper::Conv2dReLUOpWrapper(Conv2dReLUOp c) {
+  conv = c;
+}
+
+Conv2dReLUOpWrapper::~Conv2dReLUOpWrapper() {}
+
+Operation *Conv2dReLUOpWrapper::getUnderlyingOperation() {
+  return conv.getOperation();
+}
+
+Value Conv2dReLUOpWrapper::getWeights() {
+  return this->conv.getWeight();
+}
+
+ArrayRef<Value> Conv2dReLUOpWrapper::getBN() {
+  return ArrayRef<Value>();
+}
+
+Optional<Value> Conv2dReLUOpWrapper::getBiases() {
+  return this->conv.getBias();
+}
+
+Value Conv2dReLUOpWrapper::getInput() {
+  return this->conv.getInput();
+}
+
+Value Conv2dReLUOpWrapper::getPartialInput() {
+  return Value();
+}
+
+unsigned int Conv2dReLUOpWrapper::getF0() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F0_LOC];
+}
+
+unsigned int Conv2dReLUOpWrapper::getF1() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F1_LOC];
+}
+
+unsigned int Conv2dReLUOpWrapper::getStride() {
+  Value s = this->conv.getStride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+
+  return stride[0];
+}
+
+bool Conv2dReLUOpWrapper::hasWeights() {
+  return true;
+}
+
+bool Conv2dReLUOpWrapper::hasBias() {
+  return this->getBiases().has_value();
+}
+
+bool Conv2dReLUOpWrapper::hasBN() {
+  return false;
+}
+
+bool Conv2dReLUOpWrapper::isDepthWise() {
+  unsigned int groups = this->conv.getGroups()
+                            .getDefiningOp<mlir::arith::ConstantIntOp>()
+                            .value();
+  mlir::torch::Torch::BaseTensorType aShape =
+      this->conv.getInput()
+          .getType()
+          .dyn_cast<mlir::torch::Torch::BaseTensorType>();
+  ArrayRef<int64_t> aShapeAR = aShape.getSizes();
+
+  int64_t C = aShapeAR[C_LOC];
+
+  return groups == C;
+}
+
+double Conv2dReLUOpWrapper::getKernelEfficiency() {
+  if (this->isDepthWise()) {
+    return 0.30;
+  } else {
+    return 0.90;
+  }
+}
+
+Operation *Conv2dReLUOpWrapper::buildOp(OpBuilder &builder,
+                                        TypeRange returnType, Value input,
+                                        llvm::Optional<Value> weight,
+                                        llvm::Optional<Value> bias,
+                                        llvm::Optional<Value> partialIn,
+                                        bool firstInPartialChain,
+                                        llvm::Optional<ArrayRef<Value>> bn) {
+  assert(weight.has_value());
+
+  if (this->hasBias()) {
+    assert(bias.has_value());
+  }
+
+  Operation *op = this->getUnderlyingOperation();
+  Value biasVal = (bias.has_value()) ? bias.value() : this->conv.getBias();
+
+  if (firstInPartialChain || partialIn.has_value()) {
+    Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
+    Operation *nOp = builder.create<PartialConv2dReLUOp>(
+        builder.getUnknownLoc(), returnType, input, chainIn, weight.value(),
+        biasVal, this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+
+    nOp->setAttrs(op->getAttrs());
+    return nOp;
+  } else {
+    Operation *nOp = builder.create<Conv2dReLUOp>(
+        builder.getUnknownLoc(), returnType, input, weight.value(), biasVal,
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+
+    nOp->setAttrs(op->getAttrs());
+    return nOp;
+  }
+}
+
+Operation *Conv2dReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into,
+                                      llvm::Optional<TypeRange> resTypes) {
+  Operation *op;
+
+  if (resTypes.has_value()) {
+    op = builder.create<PartialConv2dReLUOp>(
+        builder.getUnknownLoc(), resTypes.value(), this->getInput(), Value(),
+        this->getWeights(), this->getBiases().value_or(nullptr),
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+  } else {
+    op = builder.create<Conv2dReLUOp>(
+        builder.getUnknownLoc(),
+        this->getUnderlyingOperation()->getResultTypes(), this->getInput(),
+        this->getWeights(), this->getBiases().value_or(nullptr),
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups());
+  }
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+PartialConv2dReLUOpWrapper::PartialConv2dReLUOpWrapper(PartialConv2dReLUOp c) {
+  conv = c;
+}
+
+PartialConv2dReLUOpWrapper::~PartialConv2dReLUOpWrapper() {}
+
+Operation *PartialConv2dReLUOpWrapper::getUnderlyingOperation() {
+  return conv.getOperation();
+}
+
+Value PartialConv2dReLUOpWrapper::getWeights() {
+  return this->conv.getWeight();
+}
+
+ArrayRef<Value> PartialConv2dReLUOpWrapper::getBN() {
+  return ArrayRef<Value>();
+}
+
+Optional<Value> PartialConv2dReLUOpWrapper::getBiases() {
+  return this->conv.getBias();
+}
+
+Value PartialConv2dReLUOpWrapper::getInput() {
+  return this->conv.getInput();
+}
+
+Value PartialConv2dReLUOpWrapper::getPartialInput() {
+  return this->conv.getPartialIn();
+}
+
+unsigned int PartialConv2dReLUOpWrapper::getF0() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F0_LOC];
+}
+
+unsigned int PartialConv2dReLUOpWrapper::getF1() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F1_LOC];
+}
+
+unsigned int PartialConv2dReLUOpWrapper::getStride() {
+  Value s = this->conv.getStride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+
+  return stride[0];
+}
+
+bool PartialConv2dReLUOpWrapper::hasWeights() {
+  return true;
+}
+
+bool PartialConv2dReLUOpWrapper::hasBias() {
+  return this->getBiases().has_value();
+}
+
+bool PartialConv2dReLUOpWrapper::hasBN() {
+  return false;
+}
+
+bool PartialConv2dReLUOpWrapper::isDepthWise() {
+  unsigned int groups = this->conv.getGroups()
+                            .getDefiningOp<mlir::arith::ConstantIntOp>()
+                            .value();
+  mlir::torch::Torch::BaseTensorType aShape =
+      this->conv.getInput()
+          .getType()
+          .dyn_cast<mlir::torch::Torch::BaseTensorType>();
+  ArrayRef<int64_t> aShapeAR = aShape.getSizes();
+
+  int64_t C = aShapeAR[C_LOC];
+
+  return groups == C;
+}
+
+double PartialConv2dReLUOpWrapper::getKernelEfficiency() {
+  if (this->isDepthWise()) {
+    return 0.30;
+  } else {
+    return 0.90;
+  }
+}
+
+Operation *PartialConv2dReLUOpWrapper::buildOp(
+    OpBuilder &builder, TypeRange returnType, Value input,
+    llvm::Optional<Value> weight, llvm::Optional<Value> bias,
+    llvm::Optional<Value> partialIn, bool firstInPartialChain,
+    llvm::Optional<ArrayRef<Value>> bn) {
+  assert(weight.has_value());
+
+  if (this->hasBias()) {
+    assert(bias.has_value());
+  }
+
+  Value chainIn;
+  if (partialIn.has_value()) {
+    chainIn = partialIn.value();
+  } else if (this->conv.getPartialIn()) {
+    chainIn = this->conv.getPartialIn();
+  } else {
+    chainIn = Value();
+  }
+
+  Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
+
+  Operation *op = this->getUnderlyingOperation();
+  Operation *nOp = builder.create<PartialConv2dReLUOp>(
+      builder.getUnknownLoc(), returnType, input, chainIn, weight.value(),
+      biasVal, this->conv.getStride(), this->conv.getPadding(),
+      this->conv.getDilation(), this->conv.getGroups());
+  nOp->setAttrs(op->getAttrs());
+  return nOp;
+}
+
+Operation *
+PartialConv2dReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into,
+                                  llvm::Optional<TypeRange> resTypes) {
+  Operation *op;
+
+  if (resTypes.has_value()) {
+    op = builder.create<PartialConv2dReLUOp>(
+        builder.getUnknownLoc(), resTypes.value(), this->getInput(),
+        this->conv.getPartialIn(), this->getWeights(),
+        this->getBiases().value_or(nullptr), this->conv.getStride(),
+        this->conv.getPadding(), this->conv.getDilation(),
+        this->conv.getGroups());
+  } else {
+    op = builder.create<PartialConv2dReLUOp>(
+        builder.getUnknownLoc(),
+        this->getUnderlyingOperation()->getResultTypes(), this->getInput(),
+        this->conv.getPartialIn(), this->getWeights(),
+        this->getBiases().value_or(nullptr), this->conv.getStride(),
+        this->conv.getPadding(), this->conv.getDilation(),
+        this->conv.getGroups());
+  }
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+PartialConv2dBatchNormReLUOpWrapper::PartialConv2dBatchNormReLUOpWrapper(
+    PartialConv2dBatchNormReLUOp c) {
+  conv = c;
+}
+
+PartialConv2dBatchNormReLUOpWrapper::~PartialConv2dBatchNormReLUOpWrapper() {}
+
+Operation *PartialConv2dBatchNormReLUOpWrapper::getUnderlyingOperation() {
+  return conv.getOperation();
+}
+
+Value PartialConv2dBatchNormReLUOpWrapper::getWeights() {
+  return this->conv.getWeight();
+}
+
+ArrayRef<Value> PartialConv2dBatchNormReLUOpWrapper::getBN() {
+  return ArrayRef<Value>({this->conv.getBnWeight(), this->conv.getBnBias(),
+                          this->conv.getRunningMean(),
+                          this->conv.getRunningVar()});
+}
+
+Optional<Value> PartialConv2dBatchNormReLUOpWrapper::getBiases() {
+  return this->conv.getBias();
+}
+
+Value PartialConv2dBatchNormReLUOpWrapper::getInput() {
+  return this->conv.getInput();
+}
+
+Value PartialConv2dBatchNormReLUOpWrapper::getPartialInput() {
+  return this->conv.getPartialIn();
+}
+
+unsigned int PartialConv2dBatchNormReLUOpWrapper::getF0() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F0_LOC];
+}
+
+unsigned int PartialConv2dBatchNormReLUOpWrapper::getF1() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F1_LOC];
+}
+
+unsigned int PartialConv2dBatchNormReLUOpWrapper::getStride() {
+  Value s = this->conv.getStride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+
+  return stride[0];
+}
+
+bool PartialConv2dBatchNormReLUOpWrapper::hasWeights() {
+  return true;
+}
+
+bool PartialConv2dBatchNormReLUOpWrapper::hasBias() {
+  return this->getBiases().has_value();
+}
+
+bool PartialConv2dBatchNormReLUOpWrapper::hasBN() {
+  return true;
+}
+
+bool PartialConv2dBatchNormReLUOpWrapper::isDepthWise() {
+  unsigned int groups = this->conv.getGroups()
+                            .getDefiningOp<mlir::arith::ConstantIntOp>()
+                            .value();
+  mlir::torch::Torch::BaseTensorType aShape =
+      this->conv.getInput()
+          .getType()
+          .dyn_cast<mlir::torch::Torch::BaseTensorType>();
+  ArrayRef<int64_t> aShapeAR = aShape.getSizes();
+
+  int64_t C = aShapeAR[C_LOC];
+
+  return groups == C;
+}
+
+double PartialConv2dBatchNormReLUOpWrapper::getKernelEfficiency() {
+  if (this->isDepthWise()) {
+    return 0.30;
+  } else {
+    return 0.90;
+  }
+}
+
+Operation *PartialConv2dBatchNormReLUOpWrapper::buildOp(
+    OpBuilder &builder, TypeRange returnType, Value input,
+    llvm::Optional<Value> weight, llvm::Optional<Value> bias,
+    llvm::Optional<Value> partialIn, bool firstInPartialChain,
+    llvm::Optional<ArrayRef<Value>> bn) {
+  assert(weight.has_value());
+  assert(bn.has_value());
+
+  if (this->hasBias()) {
+    assert(bias.has_value());
+  }
+
+  Value chainIn;
+  if (partialIn.has_value()) {
+    chainIn = partialIn.value();
+  } else if (this->conv.getPartialIn()) {
+    chainIn = this->conv.getPartialIn();
+  } else {
+    chainIn = Value();
+  }
+
+  Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
+
+  Operation *op = this->getUnderlyingOperation();
+  Operation *nOp = builder.create<PartialConv2dBatchNormReLUOp>(
+      builder.getUnknownLoc(), returnType, input, chainIn, weight.value(),
+      biasVal, this->conv.getStride(), this->conv.getPadding(),
+      this->conv.getDilation(), this->conv.getGroups(), bn.value()[0],
+      bn.value()[1], bn.value()[2], bn.value()[3], this->conv.getTraining(),
+      this->conv.getMomentum(), this->conv.getEps());
+
+  nOp->setAttrs(op->getAttrs());
+  return nOp;
+}
+
+Operation *PartialConv2dBatchNormReLUOpWrapper::wCopy(
+    OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) {
+  Operation *op;
+  if (resTypes.has_value()) {
+    op = builder.create<PartialConv2dBatchNormReLUOp>(
+        builder.getUnknownLoc(), resTypes.value(), this->getInput(),
+        this->conv.getPartialIn(), this->getWeights(),
+        this->getBiases().value_or(nullptr), this->conv.getStride(),
+        this->conv.getPadding(), this->conv.getDilation(),
+        this->conv.getGroups(), this->conv.getBnWeight(),
+        this->conv.getBnBias(), this->conv.getRunningMean(),
+        this->conv.getRunningVar(), this->conv.getTraining(),
+        this->conv.getMomentum(), this->conv.getEps());
+  } else {
+    op = builder.create<PartialConv2dBatchNormReLUOp>(
+        builder.getUnknownLoc(),
+        this->getUnderlyingOperation()->getResultTypes(), this->getInput(),
+        this->conv.getPartialIn(), this->getWeights(),
+        this->getBiases().value_or(nullptr), this->conv.getStride(),
+        this->conv.getPadding(), this->conv.getDilation(),
+        this->conv.getGroups(), this->conv.getBnWeight(),
+        this->conv.getBnBias(), this->conv.getRunningMean(),
+        this->conv.getRunningVar(), this->conv.getTraining(),
+        this->conv.getMomentum(), this->conv.getEps());
+  }
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+Conv2dBatchNormReLUOpWrapper::Conv2dBatchNormReLUOpWrapper(
+    Conv2dBatchNormReLUOp c) {
+  conv = c;
+}
+
+Conv2dBatchNormReLUOpWrapper::~Conv2dBatchNormReLUOpWrapper() {}
+
+Operation *Conv2dBatchNormReLUOpWrapper::getUnderlyingOperation() {
+  return conv.getOperation();
+}
+
+Value Conv2dBatchNormReLUOpWrapper::getWeights() {
+  return this->conv.getWeight();
+}
+
+ArrayRef<Value> Conv2dBatchNormReLUOpWrapper::getBN() {
+  return ArrayRef<Value>({this->conv.getBnWeight(), this->conv.getBnBias(),
+                          this->conv.getRunningMean(),
+                          this->conv.getRunningVar()});
+}
+
+Optional<Value> Conv2dBatchNormReLUOpWrapper::getBiases() {
+  return this->conv.getBias();
+}
+
+Value Conv2dBatchNormReLUOpWrapper::getInput() {
+  return this->conv.getInput();
+}
+
+Value Conv2dBatchNormReLUOpWrapper::getPartialInput() {
+  return Value();
+}
+
+unsigned int Conv2dBatchNormReLUOpWrapper::getF0() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F0_LOC];
+}
+
+unsigned int Conv2dBatchNormReLUOpWrapper::getF1() {
+  return this->conv.getWeight()
+      .getType()
+      .dyn_cast<mlir::torch::Torch::BaseTensorType>()
+      .getSizes()[F1_LOC];
+}
+
+unsigned int Conv2dBatchNormReLUOpWrapper::getStride() {
+  Value s = this->conv.getStride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+
+  return stride[0];
+}
+
+bool Conv2dBatchNormReLUOpWrapper::hasWeights() {
+  return true;
+}
+
+bool Conv2dBatchNormReLUOpWrapper::hasBias() {
+  return this->getBiases().has_value();
+}
+
+bool Conv2dBatchNormReLUOpWrapper::hasBN() {
+  return true;
+}
+
+bool Conv2dBatchNormReLUOpWrapper::isDepthWise() {
+  unsigned int groups = this->conv.getGroups()
+                            .getDefiningOp<mlir::arith::ConstantIntOp>()
+                            .value();
+  mlir::torch::Torch::BaseTensorType aShape =
+      this->conv.getInput()
+          .getType()
+          .dyn_cast<mlir::torch::Torch::BaseTensorType>();
+  ArrayRef<int64_t> aShapeAR = aShape.getSizes();
+
+  int64_t C = aShapeAR[C_LOC];
+
+  return groups == C;
+}
+
+double Conv2dBatchNormReLUOpWrapper::getKernelEfficiency() {
+  if (this->isDepthWise()) {
+    return 0.30;
+  } else {
+    return 0.90;
+  }
+}
+
+Operation *Conv2dBatchNormReLUOpWrapper::buildOp(
+    OpBuilder &builder, TypeRange returnType, Value input,
+    llvm::Optional<Value> weight, llvm::Optional<Value> bias,
+    llvm::Optional<Value> partialIn, bool firstInPartialChain,
+    llvm::Optional<ArrayRef<Value>> bn) {
+  assert(weight.has_value());
+  assert(bn.has_value());
+
+  if (this->hasBias()) {
+    assert(bias.has_value());
+  }
+
+  Value biasVal = bias.has_value() ? bias.value() : this->conv.getBias();
+
+  Operation *op = this->getUnderlyingOperation();
+  if (firstInPartialChain || partialIn.has_value()) {
+    Value chainIn = (partialIn.has_value()) ? partialIn.value() : Value();
+    Operation *nOp = builder.create<PartialConv2dBatchNormReLUOp>(
+        builder.getUnknownLoc(), returnType, input, chainIn, weight.value(),
+        biasVal, this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups(), bn.value()[0],
+        bn.value()[1], bn.value()[2], bn.value()[3], this->conv.getTraining(),
+        this->conv.getMomentum(), this->conv.getEps());
+    nOp->setAttrs(op->getAttrs());
+
+    return nOp;
+  } else {
+    Operation *nOp = builder.create<Conv2dBatchNormReLUOp>(
+        builder.getUnknownLoc(), returnType, input, weight.value(), biasVal,
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups(), bn.value()[0],
+        bn.value()[1], bn.value()[2], bn.value()[3], this->conv.getTraining(),
+        this->conv.getMomentum(), this->conv.getEps());
+
+    nOp->setAttrs(op->getAttrs());
+
+    return nOp;
+  }
+}
+
+Operation *
+Conv2dBatchNormReLUOpWrapper::wCopy(OpBuilder &builder, unsigned int into,
+                                    llvm::Optional<TypeRange> resTypes) {
+  Operation *op;
+
+  if (resTypes.has_value()) {
+    op = builder.create<PartialConv2dBatchNormReLUOp>(
+        builder.getUnknownLoc(), resTypes.value(), this->getInput(), Value(),
+        this->getWeights(), this->getBiases().value_or(nullptr),
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups(),
+        this->conv.getBnWeight(), this->conv.getBnBias(),
+        this->conv.getRunningMean(), this->conv.getRunningVar(),
+        this->conv.getTraining(), this->conv.getMomentum(),
+        this->conv.getEps());
+  } else {
+    op = builder.create<Conv2dBatchNormReLUOp>(
+        builder.getUnknownLoc(),
+        this->getUnderlyingOperation()->getResultTypes(), this->getInput(),
+        this->getWeights(), this->getBiases().value_or(nullptr),
+        this->conv.getStride(), this->conv.getPadding(),
+        this->conv.getDilation(), this->conv.getGroups(),
+        this->conv.getBnWeight(), this->conv.getBnBias(),
+        this->conv.getRunningMean(), this->conv.getRunningVar(),
+        this->conv.getTraining(), this->conv.getMomentum(),
+        this->conv.getEps());
+  }
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+MaxPool2dOpWrapper::MaxPool2dOpWrapper(Torch::AtenMaxPool2dOp mp) {
+  maxpool = mp;
+}
+
+MaxPool2dOpWrapper::~MaxPool2dOpWrapper() {}
+
+Operation *MaxPool2dOpWrapper::getUnderlyingOperation() {
+  return maxpool.getOperation();
+}
+
+Value MaxPool2dOpWrapper::getWeights() {
+  return Value();
+}
+
+Optional<Value> MaxPool2dOpWrapper::getBiases() {
+  return Optional<Value>{};
+}
+
+unsigned int MaxPool2dOpWrapper::getF0() {
+  Value ks = this->maxpool.kernel_size();
+  SmallVector<int64_t, 2> kernel_size;
+  matchPattern(ks, Torch::m_TorchListOfConstantInts(kernel_size));
+
+  return kernel_size[0];
+}
+
+unsigned int MaxPool2dOpWrapper::getF1() {
+  Value ks = this->maxpool.kernel_size();
+  SmallVector<int64_t, 2> kernel_size;
+  matchPattern(ks, Torch::m_TorchListOfConstantInts(kernel_size));
+
+  return kernel_size[1];
+}
+
+unsigned int MaxPool2dOpWrapper::getStride() {
+  Value s = this->maxpool.stride();
+  SmallVector<int64_t, 2> stride;
+  matchPattern(s, Torch::m_TorchListOfConstantInts(stride));
+
+  return stride[0];
+}
+
+Value MaxPool2dOpWrapper::getInput() {
+  return this->maxpool.self();
+}
+
+Value MaxPool2dOpWrapper::getPartialInput() {
+  return Value();
+}
+
+ArrayRef<Value> MaxPool2dOpWrapper::getBN() {
+  return ArrayRef<Value>();
+}
+
+bool MaxPool2dOpWrapper::hasWeights() {
+  return false;
+}
+
+bool MaxPool2dOpWrapper::hasBias() {
+  return false;
+}
+
+bool MaxPool2dOpWrapper::isDepthWise() {
+  return true;
+}
+
+bool MaxPool2dOpWrapper::hasBN() {
+  return false;
+}
+
+double MaxPool2dOpWrapper::getKernelEfficiency() {
+  return 0.25;
+}
+
+Operation *MaxPool2dOpWrapper::buildOp(OpBuilder &builder, TypeRange returnType,
+                                       Value input,
+                                       llvm::Optional<Value> weight,
+                                       llvm::Optional<Value> bias,
+                                       llvm::Optional<Value> partialIn,
+                                       bool firstInPartialChain,
+                                       llvm::Optional<ArrayRef<Value>> bn) {
+  assert(!weight.has_value());
+  assert(!bias.has_value());
+  assert(!firstInPartialChain);
+  assert(!partialIn.has_value());
+
+  Operation *op = this->getUnderlyingOperation();
+  Operation *nOp = builder.create<Torch::AtenMaxPool2dOp>(
+      builder.getUnknownLoc(), returnType, input, this->maxpool.kernel_size(),
+      this->maxpool.stride(), this->maxpool.padding(), this->maxpool.dilation(),
+      this->maxpool.ceil_mode());
+
+  nOp->setAttrs(op->getAttrs());
+  return nOp;
+}
+
+Operation *MaxPool2dOpWrapper::wCopy(OpBuilder &builder, unsigned int into,
+                                     llvm::Optional<TypeRange> typeRes) {
+  assert(!typeRes.has_value());
+
+  Operation *op = builder.create<Torch::AtenMaxPool2dOp>(
+      builder.getUnknownLoc(), this->getUnderlyingOperation()->getResultTypes(),
+      this->getInput(), this->maxpool.kernel_size(), this->maxpool.stride(),
+      this->maxpool.padding(), this->maxpool.dilation(),
+      this->maxpool.ceil_mode());
+
+  op->setAttrs(this->getUnderlyingOperation()->getAttrs());
+
+  auto ty = IntegerType::get(builder.getContext(), 32);
+  auto attr = IntegerAttr::get(ty, into);
+  op->setAttr(llvm::StringRef("locW"), attr);
+
+  return op;
+}
+
+} // namespace xten
+} // namespace xilinx

--- a/lib/Transform/ATenDialectOpStats.cpp
+++ b/lib/Transform/ATenDialectOpStats.cpp
@@ -30,101 +30,109 @@ using namespace mlir::torch;
 
 namespace {
 
-template<class T>
-std::map<std::string, uint64_t> getConv2dStatisticsWithType(T o, Torch::BaseTensorType resultTy) {
-    std::map<std::string, uint64_t> toReturn;
+template <class T>
+std::map<std::string, uint64_t>
+getConv2dStatisticsWithType(T o, Torch::BaseTensorType resultTy) {
+  std::map<std::string, uint64_t> toReturn;
 
-    Torch::BaseTensorType inputTy = o.input().getType().template cast<Torch::BaseTensorType>();
-    Torch::BaseTensorType weightTy = o.weight().getType().template cast<Torch::BaseTensorType>();
-    Torch::BaseTensorType biasTy;
-    if(o.bias()) {
-        biasTy = o.bias().getType().template cast<Torch::BaseTensorType>();
-    }
+  Torch::BaseTensorType inputTy =
+      o.input().getType().template cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType weightTy =
+      o.weight().getType().template cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType biasTy;
+  if (o.bias()) {
+    biasTy = o.bias().getType().template cast<Torch::BaseTensorType>();
+  }
 
-    uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
-    uint64_t ifm_depth = inputTy.getSizes()[1];
-    uint64_t kernel_height = weightTy.getSizes()[2];
-    uint64_t kernel_width = weightTy.getSizes()[3];
+  uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
+  uint64_t ifm_depth = inputTy.getSizes()[1];
+  uint64_t kernel_height = weightTy.getSizes()[2];
+  uint64_t kernel_width = weightTy.getSizes()[3];
 
-    auto co = o.groups().getDefiningOp();
-    auto ia = co->template getAttrOfType<IntegerAttr>("value");
-    uint64_t groups = ia.getValue().getZExtValue();
-    // Number of forward MACs per pixel =
-    //  kernel_width * kernel_height * ifm_depth / groups
-    uint64_t MACs_per_OFM = (ifm_depth/groups) * kernel_height * kernel_width;
-    uint64_t total_MACs = ofm_volume * MACs_per_OFM;
+  auto co = o.groups().getDefiningOp();
+  auto ia = co->template getAttrOfType<IntegerAttr>("value");
+  uint64_t groups = ia.getValue().getZExtValue();
+  // Number of forward MACs per pixel =
+  //  kernel_width * kernel_height * ifm_depth / groups
+  uint64_t MACs_per_OFM = (ifm_depth / groups) * kernel_height * kernel_width;
+  uint64_t total_MACs = ofm_volume * MACs_per_OFM;
 
-    uint64_t ifm_volume = xilinx::xten::getTensorVolume(inputTy);
-    uint64_t weight_volume = xilinx::xten::getTensorVolume(weightTy);
-    uint64_t bias_volume;
-    if(o.bias()) {
-        bias_volume = xilinx::xten::getTensorVolume(biasTy);
-    } else {
-        bias_volume = 0;
-    }
+  uint64_t ifm_volume = xilinx::xten::getTensorVolume(inputTy);
+  uint64_t weight_volume = xilinx::xten::getTensorVolume(weightTy);
+  uint64_t bias_volume;
+  if (o.bias()) {
+    bias_volume = xilinx::xten::getTensorVolume(biasTy);
+  } else {
+    bias_volume = 0;
+  }
 
-    // Should be gated on whether there is bias at all
-    toReturn["ops:+"] = ofm_volume;
+  // Should be gated on whether there is bias at all
+  toReturn["ops:+"] = ofm_volume;
 
-    toReturn["ops:MAC"] = total_MACs;
-    toReturn["operand:0:activation_in"] = ifm_volume;
-    toReturn["result:0:activation_out"] = ofm_volume;
-    toReturn["operand:1:parameters_in:weight"] = weight_volume;
-    toReturn["operand:2:parameters_in:bias"] = bias_volume;
+  toReturn["ops:MAC"] = total_MACs;
+  toReturn["operand:0:activation_in"] = ifm_volume;
+  toReturn["result:0:activation_out"] = ofm_volume;
+  toReturn["operand:1:parameters_in:weight"] = weight_volume;
+  toReturn["operand:2:parameters_in:bias"] = bias_volume;
 
-    toReturn["reads"] = weight_volume + bias_volume + ifm_volume;
-    toReturn["writes"] = ofm_volume;
+  toReturn["reads"] = weight_volume + bias_volume + ifm_volume;
+  toReturn["writes"] = ofm_volume;
 
-    return toReturn;
+  return toReturn;
 }
 
 static bool simple_conv2d_model = false;
 
-template<class T>
-uint64_t getConv2dOperandTransferVolumeWithType(T o, unsigned int idx, bool read, Torch::BaseTensorType resultTy) {
+template <class T>
+uint64_t
+getConv2dOperandTransferVolumeWithType(T o, unsigned int idx, bool read,
+                                       Torch::BaseTensorType resultTy) {
 
-  if (!read) return 0;
+  if (!read)
+    return 0;
 
   double vol = xilinx::xten::getTensorVolume(o.getOperand(idx).getType());
   if (simple_conv2d_model)
     return vol;
 
-  Torch::BaseTensorType inputTy = o.input().getType().template cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType weightTy = o.weight().getType().template cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputTy =
+      o.input().getType().template cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType weightTy =
+      o.weight().getType().template cast<Torch::BaseTensorType>();
 
   float filter_width = weightTy.getSizes()[2];
   float filter_height = weightTy.getSizes()[3];
 
   float batch_sw = inputTy.getSizes()[0];
-  //float ifm_depth_sw = inputTy.getSizes()[1];
+  // float ifm_depth_sw = inputTy.getSizes()[1];
   float ih = inputTy.getSizes()[2];
-  //float iw = inputTy.getSizes()[3];
+  // float iw = inputTy.getSizes()[3];
 
   float ofm_depth_sw = resultTy.getSizes()[1];
 
   const float batch_hw = 4;
-  //const float ifm_depth_hw = 32;
+  // const float ifm_depth_hw = 32;
   const float ofm_depth_hw = 32;
 
   const float ifm_tile_height = 4;
-  //const float ifm_tile_width = 4;
-  //const float ofm_tile_height = 4;
-  //const float ofm_tile_width = 4;
+  // const float ifm_tile_width = 4;
+  // const float ofm_tile_height = 4;
+  // const float ofm_tile_width = 4;
 
-  float ifm_aperture = ifm_tile_height - ceilf(filter_height/2.0f);
-  float ifm_overlap = ceilf(filter_height/2.0f);
+  float ifm_aperture = ifm_tile_height - ceilf(filter_height / 2.0f);
+  float ifm_overlap = ceilf(filter_height / 2.0f);
 
   float bl = ceilf(batch_sw / batch_hw);
   float ol = ceilf(ofm_depth_sw / ofm_depth_hw);
-  //float il = ceilf(ifm_depth_sw / ifm_depth_hw);
+  // float il = ceilf(ifm_depth_sw / ifm_depth_hw);
 
   float ifm_overhead = 1.0f;
   float weight_overhead = 1.0f;
   if (filter_width > 1) {
-    ifm_overhead = ol * ifm_tile_height * ((ih - ifm_overlap) / (ih * ifm_aperture));
+    ifm_overhead =
+        ol * ifm_tile_height * ((ih - ifm_overlap) / (ih * ifm_aperture));
     weight_overhead = bl;
-  }
-  else {
+  } else {
     ifm_overhead = ol;
   }
 
@@ -139,10 +147,13 @@ uint64_t getConv2dOperandTransferVolumeWithType(T o, unsigned int idx, bool read
   return vol;
 }
 
-template<class T>
-uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx, bool write, Torch::BaseTensorType resultTy) {
+template <class T>
+uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx,
+                                               bool write,
+                                               Torch::BaseTensorType resultTy) {
 
-  Torch::BaseTensorType inputTy = o.input().getType().template cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputTy =
+      o.input().getType().template cast<Torch::BaseTensorType>();
 
   if (simple_conv2d_model) {
     if (write)
@@ -151,9 +162,10 @@ uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx, bool write
       return 0;
   }
 
-  Torch::BaseTensorType weightTy = o.weight().getType().template cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType weightTy =
+      o.weight().getType().template cast<Torch::BaseTensorType>();
   float filter_width = weightTy.getSizes()[2];
-  //float filter_height = weightTy.getSizes()[3];
+  // float filter_height = weightTy.getSizes()[3];
 
   float ifm_depth_sw = inputTy.getSizes()[1];
   const float ifm_depth_hw = 32;
@@ -171,7 +183,8 @@ uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx, bool write
   double vol = xilinx::xten::getTensorVolume(resultTy);
 
   if (write) {
-    LLVM_DEBUG(llvm::outs() << "write_output_overhead:" << write_output_overhead << "\n");
+    LLVM_DEBUG(llvm::outs()
+               << "write_output_overhead:" << write_output_overhead << "\n");
     return vol * write_output_overhead;
   } else {
     LLVM_DEBUG(llvm::outs() << "read_output_cost:" << read_output_cost << "\n");
@@ -181,26 +194,28 @@ uint64_t getConv2dResultTransferVolumeWithType(T o, unsigned int idx, bool write
 
 // TODO can this indirection be cleaned?
 
-
 // Conv2dStatistics
-template<class T>
+template <class T>
 std::map<std::string, uint64_t> getConv2dStatistics(T o) {
-    Torch::BaseTensorType resultType = o.getResult().getType().template cast<Torch::BaseTensorType>();
-    return getConv2dStatisticsWithType(o, resultType);
+  Torch::BaseTensorType resultType =
+      o.getResult().getType().template cast<Torch::BaseTensorType>();
+  return getConv2dStatisticsWithType(o, resultType);
 }
 
 // OperandTransferVolume
-template<class T>
+template <class T>
 uint64_t getConv2dOperandTransferVolume(T o, unsigned int idx, bool read) {
-    Torch::BaseTensorType resultType = o.getResult().getType().template cast<Torch::BaseTensorType>();
-    return getConv2dOperandTransferVolumeWithType(o, idx, read, resultType);
+  Torch::BaseTensorType resultType =
+      o.getResult().getType().template cast<Torch::BaseTensorType>();
+  return getConv2dOperandTransferVolumeWithType(o, idx, read, resultType);
 }
 
 // ResultTransferVolume
-template<class T>
-uint64_t  getConv2dResultTransferVolume(T o, unsigned int idx, bool write) {
-    Torch::BaseTensorType resultType = o.getResult().getType().template cast<Torch::BaseTensorType>();
-    return getConv2dResultTransferVolumeWithType(o, idx, write, resultType);
+template <class T>
+uint64_t getConv2dResultTransferVolume(T o, unsigned int idx, bool write) {
+  Torch::BaseTensorType resultType =
+      o.getResult().getType().template cast<Torch::BaseTensorType>();
+  return getConv2dResultTransferVolumeWithType(o, idx, write, resultType);
 }
 
 } // namespace
@@ -212,17 +227,17 @@ namespace xten {
 
 using namespace mlir::torch;
 
-template<class OpT>
+template <class OpT>
 std::map<std::string, uint64_t> getStatistics(OpT op) {
   return std::map<std::string, uint64_t>();
 }
 
-
 // add
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenAddTensorOp op) {
   std::map<std::string, uint64_t> toReturn;
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(aType);
@@ -244,13 +259,15 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenAddTensorOp op) {
 }
 
 // add_
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenAdd_TensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -277,14 +294,19 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenAdd_TensorOp op) {
 
 //   std::map<std::string, uint64_t> toReturn;
 
-//   // For linear, we need the number of output neurons and the number of input neurons
+//   // For linear, we need the number of output neurons and the number of input
+//   neurons
 //   // Then the number of forward MACs is input * output
 //   // And the number of adds is output if there is bias
 
-//   Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-//   Torch::BaseTensorType biasTy = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
-//   Torch::BaseTensorType inputTy = op.getOperand(1).getType().cast<Torch::BaseTensorType>();
-//   Torch::BaseTensorType weightTy = op.getOperand(2).getType().cast<Torch::BaseTensorType>();
+//   Torch::BaseTensorType resultTy =
+//   op.getResult().getType().cast<Torch::BaseTensorType>();
+//   Torch::BaseTensorType biasTy =
+//   op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+//   Torch::BaseTensorType inputTy =
+//   op.getOperand(1).getType().cast<Torch::BaseTensorType>();
+//   Torch::BaseTensorType weightTy =
+//   op.getOperand(2).getType().cast<Torch::BaseTensorType>();
 
 //   uint64_t num_output_neurons = resultTy.getSizes()[1];
 //   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -297,10 +319,11 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenAdd_TensorOp op) {
 //   uint64_t ifm_volume = xilinx::xten::getTensorVolume(inputTy);
 
 //   toReturn["ops:MAC"] = total_MACs;
-//   toReturn["ops:+"] = ofm_volume;   // Should be gated on whether there is bias at all
-//   toReturn["operand:1:activation_in"] = ifm_volume;
+//   toReturn["ops:+"] = ofm_volume;   // Should be gated on whether there is
+//   bias at all toReturn["operand:1:activation_in"] = ifm_volume;
 //   toReturn["result:0:activation_out"] = ofm_volume;
-//   toReturn["operand:0:parameters_in:bias"] = xilinx::xten::getTensorVolume(biasTy);
+//   toReturn["operand:0:parameters_in:bias"] =
+//   xilinx::xten::getTensorVolume(biasTy);
 //   toReturn["operand:2:parameters_in:weight"] = weight_volume;
 
 //   toReturn["reads"] = ifm_volume + weight_volume + num_output_neurons;
@@ -321,15 +344,18 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenAdd_TensorOp op) {
 // }
 
 // batch_norm
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenBatchNormOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
   uint64_t op_volume = xilinx::xten::getTensorVolume(resultTy);
-  uint64_t weight_volume = xilinx::xten::getTensorVolume(op.getOperand(1).getType());
-  uint64_t bias_volume = xilinx::xten::getTensorVolume(op.getOperand(2).getType());
+  uint64_t weight_volume =
+      xilinx::xten::getTensorVolume(op.getOperand(1).getType());
+  uint64_t bias_volume =
+      xilinx::xten::getTensorVolume(op.getOperand(2).getType());
   toReturn["operand:0:activation_in"] = op_volume;
   toReturn["result:0:activation_out"] = op_volume;
   toReturn["operand:1:parameters_in:weight"] = weight_volume;
@@ -338,22 +364,22 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenBatchNormOp op) {
   // Now for the arithmetic.  Assume variance is calculated as sum of squares
   uint64_t ifm_depth = resultTy.getSizes()[1];
 
-  toReturn["ops:+"] = op_volume;   // Add up for mean
-  toReturn["ops:*"] = op_volume;   // Square for variance
-  toReturn["ops:+"] += op_volume;  // Add up squares for variance
+  toReturn["ops:+"] = op_volume;  // Add up for mean
+  toReturn["ops:*"] = op_volume;  // Square for variance
+  toReturn["ops:+"] += op_volume; // Add up squares for variance
 
-  toReturn["ops:*"] += ifm_depth;   // Calc channel means
-  toReturn["ops:-"] += ifm_depth;   // Calc channel vars
-  toReturn["ops:*"] += ifm_depth;   // Calc channel vars
+  toReturn["ops:*"] += ifm_depth; // Calc channel means
+  toReturn["ops:-"] += ifm_depth; // Calc channel vars
+  toReturn["ops:*"] += ifm_depth; // Calc channel vars
 
-  toReturn["ops:sqrt"] = ifm_depth;  // Convert to SD
+  toReturn["ops:sqrt"] = ifm_depth; // Convert to SD
   toReturn["ops:/"] = ifm_depth;    // Get the reciprocal
 
-  toReturn["ops:+"] += op_volume;   // Subtract mean off each pixel
-  toReturn["ops:*"] += op_volume;   // Multiply by 1/SD for each pixel
+  toReturn["ops:+"] += op_volume; // Subtract mean off each pixel
+  toReturn["ops:*"] += op_volume; // Multiply by 1/SD for each pixel
 
-  toReturn["ops:+"] += op_volume;   // Bias
-  toReturn["ops:*"] += op_volume;   // Scale
+  toReturn["ops:+"] += op_volume; // Bias
+  toReturn["ops:*"] += op_volume; // Scale
 
   toReturn["reads"] = op_volume + weight_volume + bias_volume;
   toReturn["writes"] = op_volume;
@@ -362,16 +388,18 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenBatchNormOp op) {
 }
 
 // _convolution
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenConv2dOp op) {
   return getConv2dStatistics<Torch::AtenConv2dOp>(op);
 }
 
-uint64_t getOperandTransferVolume(Torch::AtenConv2dOp op, unsigned int idx, bool read) {
+uint64_t getOperandTransferVolume(Torch::AtenConv2dOp op, unsigned int idx,
+                                  bool read) {
   return getConv2dOperandTransferVolume<Torch::AtenConv2dOp>(op, idx, read);
 }
 
-uint64_t getResultTransferVolume(Torch::AtenConv2dOp op, unsigned int idx, bool write) {
+uint64_t getResultTransferVolume(Torch::AtenConv2dOp op, unsigned int idx,
+                                 bool write) {
   return getConv2dResultTransferVolume<Torch::AtenConv2dOp>(op, idx, write);
 }
 
@@ -380,38 +408,45 @@ uint64_t getResultTransferVolume(Torch::AtenConv2dOp op, unsigned int idx, bool 
 // std::map<std::string, uint64_t> getStatistics(ConvolutionBackwardOp op) {
 
 //   std::map<std::string, uint64_t> toReturn;
-//   Torch::BaseTensorType dx_out_resultTy = op.getResult(0).getType().cast<Torch::BaseTensorType>();
-//   uint64_t dx_out_volume = xilinx::xten::getTensorVolume(dx_out_resultTy);
+//   Torch::BaseTensorType dx_out_resultTy =
+//   op.getResult(0).getType().cast<Torch::BaseTensorType>(); uint64_t
+//   dx_out_volume = xilinx::xten::getTensorVolume(dx_out_resultTy);
 
-//   Torch::BaseTensorType weightTy = op.getOperand(2).getType().cast<Torch::BaseTensorType>();
-//   uint64_t weight_volume = xilinx::xten::getTensorVolume(weightTy);
-//   uint64_t loss_in_depth = weightTy.getSizes()[0];
-//   uint64_t kernel_width = weightTy.getSizes()[2];
-//   uint64_t kernel_height = weightTy.getSizes()[3];
+//   Torch::BaseTensorType weightTy =
+//   op.getOperand(2).getType().cast<Torch::BaseTensorType>(); uint64_t
+//   weight_volume = xilinx::xten::getTensorVolume(weightTy); uint64_t
+//   loss_in_depth = weightTy.getSizes()[0]; uint64_t kernel_width =
+//   weightTy.getSizes()[2]; uint64_t kernel_height = weightTy.getSizes()[3];
 
 //   uint64_t groups = 1; // todo: get this in the same way as the forward path
-//   uint64_t MACs_per_loss = (loss_in_depth/groups) * kernel_height * kernel_width;
+//   uint64_t MACs_per_loss = (loss_in_depth/groups) * kernel_height *
+//   kernel_width;
 
 //   uint64_t total_MACs = dx_out_volume * MACs_per_loss;
 
-//   Torch::BaseTensorType ifmTy = op.getOperand(1).getType().cast<Torch::BaseTensorType>();
-//   uint64_t ifm_volume = xilinx::xten::getTensorVolume(ifmTy);
-//   auto ifm_shape = ifmTy.getSizes();
+//   Torch::BaseTensorType ifmTy =
+//   op.getOperand(1).getType().cast<Torch::BaseTensorType>(); uint64_t
+//   ifm_volume = xilinx::xten::getTensorVolume(ifmTy); auto ifm_shape =
+//   ifmTy.getSizes();
 
-//   uint64_t ifm_bwh = ifm_shape[0]*ifm_shape[2]*ifm_shape[3];  // Batch * height * width: the depth is in the weight shape already
-//   total_MACs += ifm_bwh * weight_volume;
+//   uint64_t ifm_bwh = ifm_shape[0]*ifm_shape[2]*ifm_shape[3];  // Batch *
+//   height * width: the depth is in the weight shape already total_MACs +=
+//   ifm_bwh * weight_volume;
 
-//   Torch::BaseTensorType dx_inTy = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
-//   uint64_t dx_in_volume = xilinx::xten::getTensorVolume(dx_inTy);
-//   toReturn["ops:+"] = dx_in_volume;
+//   Torch::BaseTensorType dx_inTy =
+//   op.getOperand(0).getType().cast<Torch::BaseTensorType>(); uint64_t
+//   dx_in_volume = xilinx::xten::getTensorVolume(dx_inTy); toReturn["ops:+"] =
+//   dx_in_volume;
 
-//   // Reads: Conv_backward reads 3 tensors: the loss in, the activation in and the transposed weights
-//   toReturn["reads"] = dx_in_volume + ifm_volume + weight_volume;
+//   // Reads: Conv_backward reads 3 tensors: the loss in, the activation in and
+//   the transposed weights toReturn["reads"] = dx_in_volume + ifm_volume +
+//   weight_volume;
 
-//   // Writes: Conv_backward writes 3 tensors: the loss out, gradients for the weights, and gradients for the biases
-//   Torch::BaseTensorType biasTy = op.getResult(2).getType().cast<Torch::BaseTensorType>();
-//   uint64_t bias_volume = xilinx::xten::getTensorVolume(biasTy);
-//   toReturn["writes"] = dx_out_volume + weight_volume + bias_volume;
+//   // Writes: Conv_backward writes 3 tensors: the loss out, gradients for the
+//   weights, and gradients for the biases Torch::BaseTensorType biasTy =
+//   op.getResult(2).getType().cast<Torch::BaseTensorType>(); uint64_t
+//   bias_volume = xilinx::xten::getTensorVolume(biasTy); toReturn["writes"] =
+//   dx_out_volume + weight_volume + bias_volume;
 
 //   toReturn["ops:MAC"] = total_MACs;
 //   toReturn["operand:0:activation_in"] = dx_in_volume;
@@ -421,18 +456,20 @@ uint64_t getResultTransferVolume(Torch::AtenConv2dOp op, unsigned int idx, bool 
 //   toReturn["result:0:grad:dx"] = dx_out_volume;
 //   toReturn["result:1:grad:dw"] = weight_volume;
 //   toReturn["result:2:grad:db"] = bias_volume;
- 
+
 //   return toReturn;
 // }
 
 // div
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenDivTensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -449,19 +486,20 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenDivTensorOp op) {
 
   toReturn["reads"] = a_volume + b_volume;
   toReturn["writes"] = ofm_volume;
-
 
   return toReturn;
 }
 
 // div_
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenDiv_TensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -478,43 +516,45 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenDiv_TensorOp op) {
   toReturn["reads"] = a_volume + b_volume;
   toReturn["writes"] = ofm_volume;
 
-
   return toReturn;
 }
 
 // expand can be zero overhead
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenExpandOp op) {
   std::map<std::string, uint64_t> toReturn;
-  toReturn["reads"]  = toReturn["operand:0:activation_in"] = 0;
+  toReturn["reads"] = toReturn["operand:0:activation_in"] = 0;
   toReturn["writes"] = toReturn["result:0:activation_out"] = 0;
   return toReturn;
 }
 
 // flatten can be zero overhead
-template<>
-std::map<std::string, uint64_t> getStatistics(Torch::AtenFlattenUsingIntsOp op) {
+template <>
+std::map<std::string, uint64_t>
+getStatistics(Torch::AtenFlattenUsingIntsOp op) {
   std::map<std::string, uint64_t> toReturn;
-  toReturn["reads"]  = toReturn["operand:0:activation_in"] = 0;
+  toReturn["reads"] = toReturn["operand:0:activation_in"] = 0;
   toReturn["writes"] = toReturn["result:0:activation_out"] = 0;
   return toReturn;
 }
 
 // tanh
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenTanhOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType inputTy = op.getOperand().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputTy =
+      op.getOperand().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
 
   uint64_t in_volume = xilinx::xten::getTensorVolume(inputTy);
   uint64_t out_volume = xilinx::xten::getTensorVolume(resultTy);
 
   toReturn["operand:0:activation_in"] = in_volume;
   toReturn["result:0:activation_out"] = out_volume;
-  toReturn["reads"]  = in_volume;
+  toReturn["reads"] = in_volume;
   toReturn["writes"] = out_volume;
   toReturn["ops:>"] = out_volume;
 
@@ -522,20 +562,22 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenTanhOp op) {
 }
 
 // tanh_
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenTanh_Op op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType inputTy = op.getOperand().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputTy =
+      op.getOperand().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
 
   uint64_t in_volume = xilinx::xten::getTensorVolume(inputTy);
   uint64_t out_volume = xilinx::xten::getTensorVolume(resultTy);
 
   toReturn["operand:0:activation_in"] = in_volume;
   toReturn["result:0:activation_out"] = out_volume;
-  toReturn["reads"]  = in_volume;
+  toReturn["reads"] = in_volume;
   toReturn["writes"] = out_volume;
   toReturn["ops:>"] = out_volume;
 
@@ -543,13 +585,15 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenTanh_Op op) {
 }
 
 // max_pool2d
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenMaxPool2dOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType inputType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
   toReturn["result:0:activation_out"] = ofm_volume;
@@ -559,11 +603,11 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMaxPool2dOp op) {
 
   // To find the number of compares, we need the filter extent
 
-  SmallVector<int64_t,2> kernel_size;
-  matchPattern(op.getOperand(1), Torch::m_TorchConstantIntList(kernel_size));
+  SmallVector<int64_t, 2> kernel_size;
+  matchPattern(op.getOperand(1), Torch::m_TorchListOfConstantInts(kernel_size));
 
   uint64_t aperture = kernel_size[0] * kernel_size[1];
-  toReturn["ops:>"] = ofm_volume * (aperture-1);
+  toReturn["ops:>"] = ofm_volume * (aperture - 1);
 
   toReturn["reads"] = ifm_volume;
   toReturn["writes"] = ofm_volume;
@@ -577,20 +621,23 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMaxPool2dOp op) {
 
 //     std::map<std::string, uint64_t> toReturn;
 
-//     uint64_t ofm_volume = xilinx::xten::getTensorVolume(op.getResult(0).getType().cast<Torch::BaseTensorType>());
-//     uint64_t indices_volume = xilinx::xten::getTensorVolume(op.getResult(1).getType().cast<Torch::BaseTensorType>());
+//     uint64_t ofm_volume =
+//     xilinx::xten::getTensorVolume(op.getResult(0).getType().cast<Torch::BaseTensorType>());
+//     uint64_t indices_volume =
+//     xilinx::xten::getTensorVolume(op.getResult(1).getType().cast<Torch::BaseTensorType>());
 
 //     toReturn["writes"] = ofm_volume + indices_volume;
 //     toReturn["result:0:activation_out"] = ofm_volume;
 //     toReturn["result:1:indices_out"] = indices_volume;
 
-//     uint64_t ifm_volume = xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
+//     uint64_t ifm_volume =
+//     xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
 //     toReturn["reads"] = ifm_volume;
 //     toReturn["operand:0:activation_in"] = ifm_volume;
 
 //     // To find the number of compares, we need the filter extent
 //     std::vector<int64_t> kernel_size;
-    
+
 //     matchPattern(op.getOperand(1), m_TorchConstantIntList(kernel_size));
 
 //     uint64_t aperture = kernel_size[0] * kernel_size[1];
@@ -601,18 +648,23 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMaxPool2dOp op) {
 
 // max_pool2d_with_indicies_backward
 // template<>
-// std::map<std::string, uint64_t> getStatistics(MaxPool2dWithIndicesBackwardOp op) {
+// std::map<std::string, uint64_t> getStatistics(MaxPool2dWithIndicesBackwardOp
+// op) {
 
 //   std::map<std::string, uint64_t> toReturn;
 
 //   Type resultTy = op.getResult().getType();
-//   Torch::BaseTensorType tensorResultTy = resultTy.cast<Torch::BaseTensorType>();
-//   uint64_t loss_out_volume = xilinx::xten::getTensorVolume(tensorResultTy);
-//   toReturn["writes"] = loss_out_volume;
+//   Torch::BaseTensorType tensorResultTy =
+//   resultTy.cast<Torch::BaseTensorType>(); uint64_t loss_out_volume =
+//   xilinx::xten::getTensorVolume(tensorResultTy); toReturn["writes"] =
+//   loss_out_volume;
 
-//   uint64_t loss_in_volume = xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
-//   uint64_t act_in_volume  = xilinx::xten::getTensorVolume(op.getOperand(1).getType().cast<Torch::BaseTensorType>()); // TODO: Why is this needed?
-//   uint64_t indices_volume  = xilinx::xten::getTensorVolume(op.getOperand(7).getType().cast<Torch::BaseTensorType>());
+//   uint64_t loss_in_volume =
+//   xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
+//   uint64_t act_in_volume  =
+//   xilinx::xten::getTensorVolume(op.getOperand(1).getType().cast<Torch::BaseTensorType>());
+//   // TODO: Why is this needed? uint64_t indices_volume  =
+//   xilinx::xten::getTensorVolume(op.getOperand(7).getType().cast<Torch::BaseTensorType>());
 //   toReturn["reads"] = loss_in_volume + act_in_volume + indices_volume;
 //   toReturn["operand:0:activation_in"] = loss_in_volume;
 //   toReturn["operand:1:activation_in"] = act_in_volume;
@@ -628,8 +680,10 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMaxPool2dOp op) {
 
 //   std::map<std::string, uint64_t> toReturn;
 
-//   Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-//   Torch::BaseTensorType aType = op.getOperand().getType().cast<Torch::BaseTensorType>();
+//   Torch::BaseTensorType resultTy =
+//   op.getResult().getType().cast<Torch::BaseTensorType>();
+//   Torch::BaseTensorType aType =
+//   op.getOperand().getType().cast<Torch::BaseTensorType>();
 
 //   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
 //   toReturn["ops:+"] = ofm_volume;
@@ -647,22 +701,26 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMaxPool2dOp op) {
 // }
 
 // mm
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenMmOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
 
   // Use the weight tensor to find the number of input neurons
-  Torch::BaseTensorType weightTy = op.getOperand(1).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType weightTy =
+      op.getOperand(1).getType().cast<Torch::BaseTensorType>();
   uint64_t num_input_neurons = weightTy.getSizes()[0];
   uint64_t total_MACs = ofm_volume * num_input_neurons;
   toReturn["ops:MAC"] = total_MACs;
 
-  uint64_t loss_in_volume = xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
-  uint64_t weight_volume = xilinx::xten::getTensorVolume(op.getOperand(1).getType().cast<Torch::BaseTensorType>());
+  uint64_t loss_in_volume = xilinx::xten::getTensorVolume(
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>());
+  uint64_t weight_volume = xilinx::xten::getTensorVolume(
+      op.getOperand(1).getType().cast<Torch::BaseTensorType>());
   toReturn["reads"] = loss_in_volume + weight_volume;
   toReturn["writes"] = ofm_volume;
 
@@ -673,13 +731,15 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMmOp op) {
 }
 
 // mul
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenMulTensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -700,13 +760,15 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMulTensorOp op) {
 }
 
 // mul_
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenMul_TensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -736,7 +798,8 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMul_TensorOp op) {
 //   uint64_t input_volume = xilinx::xten::getTensorVolume(inputTy);
 //   uint64_t input_channels = inputTy.getSizes()[1];
 
-//   // from https://gitenterprise.xilinx.com/nfraser/torchscope/blob/master/torchscope/helper.py
+//   // from
+//   https://gitenterprise.xilinx.com/nfraser/torchscope/blob/master/torchscope/helper.py
 //   // # 3 components make up the gradInput: 1 gradInput, 2 gradMean, 3 gradVar
 //   // # totalGradInput = gradInput + (dL / dMean * dMean / dInput) +
 //   // #                  (dL / dVar * dVar / dInput)
@@ -751,34 +814,44 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMul_TensorOp op) {
 //   // # dL / dGradVar
 //   // total_ops["backward"]["pow"] = in_c
 //   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c
-//   // #total_ops["backward"]["+"] = total_ops["backward"]["+"] + in_c * in_h*in_w*batch_size # Subtract mean, bootstrap from previous calculation
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c * (in_h*in_w*batch_size)
-//   toReturn["ops:pow"] = input_channels;;
+//   // #total_ops["backward"]["+"] = total_ops["backward"]["+"] + in_c *
+//   in_h*in_w*batch_size # Subtract mean, bootstrap from previous calculation
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c *
+//   (in_h*in_w*batch_size) toReturn["ops:pow"] = input_channels;;
 //   toReturn["ops:*"] += input_channels;
 //   toReturn["ops:*"] += input_volume;
 
 //   // # dL / dGradMean
-//   // #total_ops["backward"]["+"] = total_ops["backward"]["+"] + in_c * (in_h*in_w*batch_size) # bootstrap from previous
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale gradMean
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # eltwise with dL / dGradVar
-//   // total_ops["backward"]["+"] = in_c * (in_h*in_w*batch_size) # sum gradXhat
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale gradXhat
-//   toReturn["ops:*"] += input_channels; // scale gradMean
+//   // #total_ops["backward"]["+"] = total_ops["backward"]["+"] + in_c *
+//   (in_h*in_w*batch_size) # bootstrap from previous
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale
+//   gradMean
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # eltwise
+//   with dL / dGradVar
+//   // total_ops["backward"]["+"] = in_c * (in_h*in_w*batch_size) # sum
+//   gradXhat
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale
+//   gradXhat toReturn["ops:*"] += input_channels; // scale gradMean
 //   toReturn["ops:*"] += input_channels; // eltwise with dL / dGradVar
 //   toReturn["ops:+"] = input_volume; // sum gradXhat
 //   toReturn["ops:*"] += input_channels; // scale gradXhat
 
 //   // # totalGradInput
-//   // total_ops["backward"]["+"] = total_ops["backward"]["+"] + in_c * (in_h*in_w*batch_size) # Subtract mean, can't bootstrap this one
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale dL / dMean
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale dL / dVar
-//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c * (in_h*in_w*batch_size) # Eltwise multiply by dL / dVar
-//   // total_ops["backward"]["+"] = total_ops["backward"]["+"] + 2 * in_c * (in_h*in_w*batch_size) # Accumulate gradient terms
-//   toReturn["ops:+"] += input_volume; // Subtract mean, can't bootstrap this one
-//   toReturn["ops:*"] += input_channels; // scale dL / dMean
-//   toReturn["ops:*"] += input_channels; // scale dL / dVar
-//   toReturn["ops:*"] += input_volume; // Eltwise multiply by dL / dVar
-//   toReturn["OPS:+"] += 2 * input_volume; // Accumulate gradient terms
+//   // total_ops["backward"]["+"] = total_ops["backward"]["+"] + in_c *
+//   (in_h*in_w*batch_size) # Subtract mean, can't bootstrap this one
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale
+//   dL / dMean
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c # scale
+//   dL / dVar
+//   // total_ops["backward"]["*"] = total_ops["backward"]["*"] + in_c *
+//   (in_h*in_w*batch_size) # Eltwise multiply by dL / dVar
+//   // total_ops["backward"]["+"] = total_ops["backward"]["+"] + 2 * in_c *
+//   (in_h*in_w*batch_size) # Accumulate gradient terms toReturn["ops:+"] +=
+//   input_volume; // Subtract mean, can't bootstrap this one toReturn["ops:*"]
+//   += input_channels; // scale dL / dMean toReturn["ops:*"] += input_channels;
+//   // scale dL / dVar toReturn["ops:*"] += input_volume; // Eltwise multiply
+//   by dL / dVar toReturn["OPS:+"] += 2 * input_volume; // Accumulate gradient
+//   terms
 
 //   uint64_t reads = 0;
 //   for (int i=0; i<7; i++) {
@@ -801,20 +874,22 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMul_TensorOp op) {
 // }
 
 // relu
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenReluOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType inputTy = op.getOperand().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputTy =
+      op.getOperand().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
 
   uint64_t in_volume = xilinx::xten::getTensorVolume(inputTy);
   uint64_t out_volume = xilinx::xten::getTensorVolume(resultTy);
 
   toReturn["operand:0:activation_in"] = in_volume;
   toReturn["result:0:activation_out"] = out_volume;
-  toReturn["reads"]  = in_volume;
+  toReturn["reads"] = in_volume;
   toReturn["writes"] = out_volume;
   toReturn["ops:>"] = out_volume;
 
@@ -822,20 +897,22 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenReluOp op) {
 }
 
 // relu_
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenRelu_Op op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType inputTy = op.getOperand().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType inputTy =
+      op.getOperand().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
 
   uint64_t in_volume = xilinx::xten::getTensorVolume(inputTy);
   uint64_t out_volume = xilinx::xten::getTensorVolume(resultTy);
 
   toReturn["operand:0:activation_in"] = in_volume;
   toReturn["result:0:activation_out"] = out_volume;
-  toReturn["reads"]  = in_volume;
+  toReturn["reads"] = in_volume;
   toReturn["writes"] = out_volume;
   toReturn["ops:>"] = out_volume;
 
@@ -843,13 +920,15 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenRelu_Op op) {
 }
 
 // sub
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenSubTensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -868,17 +947,18 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenSubTensorOp op) {
   toReturn["writes"] = ofm_volume;
 
   return toReturn;
-
 }
 
 // sub_
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenSub_TensorOp op) {
 
   std::map<std::string, uint64_t> toReturn;
 
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
-  Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType resultTy =
+      op.getResult().getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType aType =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
   uint64_t ofm_volume = xilinx::xten::getTensorVolume(resultTy);
@@ -900,11 +980,12 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenSub_TensorOp op) {
 }
 
 // sum
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenSumOp op) {
 
   std::map<std::string, uint64_t> toReturn;
-  Torch::BaseTensorType ty = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType ty =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   uint64_t volume = xilinx::xten::getTensorVolume(ty);
 
   toReturn["ops:+"] = volume;
@@ -918,12 +999,13 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenSumOp op) {
   return toReturn;
 }
 
-// scalar mul 
-template<>
+// scalar mul
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenMulScalarOp op) {
 
   std::map<std::string, uint64_t> toReturn;
-  Torch::BaseTensorType ty = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
+  Torch::BaseTensorType ty =
+      op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   uint64_t volume = xilinx::xten::getTensorVolume(ty);
 
   toReturn["ops:*"] = volume;
@@ -942,56 +1024,60 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenMulScalarOp op) {
 // std::map<std::string, uint64_t> getStatistics(ThresholdBackwardOp op) {
 
 //   std::map<std::string, uint64_t> toReturn;
-//   uint64_t loss_in_volume = xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
-//   uint64_t act_in_volume  = xilinx::xten::getTensorVolume(op.getOperand(1).getType().cast<Torch::BaseTensorType>());
-//   uint64_t loss_out_volume = xilinx::xten::getTensorVolume(op.getResult().getType().cast<Torch::BaseTensorType>());
+//   uint64_t loss_in_volume =
+//   xilinx::xten::getTensorVolume(op.getOperand(0).getType().cast<Torch::BaseTensorType>());
+//   uint64_t act_in_volume  =
+//   xilinx::xten::getTensorVolume(op.getOperand(1).getType().cast<Torch::BaseTensorType>());
+//   uint64_t loss_out_volume =
+//   xilinx::xten::getTensorVolume(op.getResult().getType().cast<Torch::BaseTensorType>());
 
-//   toReturn["reads"]  = toReturn["operand:0:activation_in"] = loss_in_volume + act_in_volume;
-//   toReturn["writes"] = toReturn["result:0:grad:dx"] = loss_out_volume;
+//   toReturn["reads"]  = toReturn["operand:0:activation_in"] = loss_in_volume +
+//   act_in_volume; toReturn["writes"] = toReturn["result:0:grad:dx"] =
+//   loss_out_volume;
 
 //   return toReturn;
 // }
 
 // transpose can be zero overhead
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenTransposeIntOp op) {
   std::map<std::string, uint64_t> toReturn;
-  toReturn["reads"]  = toReturn["operand:0:activation_in"] = 0;
+  toReturn["reads"] = toReturn["operand:0:activation_in"] = 0;
   toReturn["writes"] = toReturn["result:0:activation_out"] = 0;
   return toReturn;
 }
 
 // unsqueeze can be zero overhead
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenUnsqueezeOp op) {
   std::map<std::string, uint64_t> toReturn;
-  toReturn["reads"]  = toReturn["operand:0:activation_in"] = 0;
+  toReturn["reads"] = toReturn["operand:0:activation_in"] = 0;
   toReturn["writes"] = toReturn["result:0:activation_out"] = 0;
   return toReturn;
 }
 
 // view can be zero overhead
-template<>
+template <>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenViewOp op) {
   std::map<std::string, uint64_t> toReturn;
-  toReturn["reads"]  = toReturn["operand:0:activation_in"] = 0;
+  toReturn["reads"] = toReturn["operand:0:activation_in"] = 0;
   toReturn["writes"] = toReturn["result:0:activation_out"] = 0;
   return toReturn;
 }
 
-std::map<std::string, uint64_t> getATenOpStats(Operation *op)
-{
+std::map<std::string, uint64_t> getATenOpStats(Operation *op) {
 
-#define GET_STATS(T) \
-  if (isa<T>(op)) return getStatistics<T>( cast<T>(op) );
+#define GET_STATS(T)                                                           \
+  if (isa<T>(op))                                                              \
+    return getStatistics<T>(cast<T>(op));
   GET_STATS(Torch::AtenMulScalarOp)
   GET_STATS(Torch::AtenAddTensorOp)
   GET_STATS(Torch::AtenAdd_TensorOp)
-//  GET_STATS(AddmmOp)
-//  GET_STATS(AsStridedOp)
+  //  GET_STATS(AddmmOp)
+  //  GET_STATS(AsStridedOp)
   GET_STATS(Torch::AtenBatchNormOp)
   GET_STATS(Torch::AtenConv2dOp)
-//  GET_STATS(ConvolutionBackwardOp)
+  //  GET_STATS(ConvolutionBackwardOp)
   GET_STATS(Torch::AtenDivTensorOp)
   GET_STATS(Torch::AtenDiv_TensorOp)
   GET_STATS(Torch::AtenExpandOp)
@@ -999,19 +1085,19 @@ std::map<std::string, uint64_t> getATenOpStats(Operation *op)
   GET_STATS(Torch::AtenTanhOp)
   GET_STATS(Torch::AtenTanh_Op)
   GET_STATS(Torch::AtenMaxPool2dOp)
-//  GET_STATS(MaxPool2dWithIndicesOp)
-//  GET_STATS(MaxPool2dWithIndicesBackwardOp)
-//  GET_STATS(MeanOp)
+  //  GET_STATS(MaxPool2dWithIndicesOp)
+  //  GET_STATS(MaxPool2dWithIndicesBackwardOp)
+  //  GET_STATS(MeanOp)
   GET_STATS(Torch::AtenMmOp)
   GET_STATS(Torch::AtenMulTensorOp)
   GET_STATS(Torch::AtenMul_TensorOp)
-//  GET_STATS(NativeBatchNormBackwardOp)
+  //  GET_STATS(NativeBatchNormBackwardOp)
   GET_STATS(Torch::AtenReluOp)
   GET_STATS(Torch::AtenRelu_Op)
   GET_STATS(Torch::AtenSubTensorOp)
   GET_STATS(Torch::AtenSub_TensorOp)
   GET_STATS(Torch::AtenSumOp)
-//  GET_STATS(ThresholdBackwardOp)
+  //  GET_STATS(ThresholdBackwardOp)
   GET_STATS(Torch::AtenTransposeIntOp)
   GET_STATS(Torch::AtenUnsqueezeOp)
   GET_STATS(Torch::AtenViewOp)

--- a/lib/Transform/ATenVisualGraph.cpp
+++ b/lib/Transform/ATenVisualGraph.cpp
@@ -93,7 +93,7 @@ inline std::string vector_to_str(std::vector<int64_t> vec_input,
 
 void unpack_int_list(const Value &op, std::vector<int64_t> &v) {
   SmallVector<int64_t, 2> sv;
-  if (matchPattern(op, Torch::m_TorchConstantIntList(sv))) {
+  if (matchPattern(op, Torch::m_TorchListOfConstantInts(sv))) {
     for (size_t i = 0; i < sv.size(); i++)
       v.push_back(sv[i]);
   } else if (auto co = op.getDefiningOp<arith::ConstantIntOp>()) {
@@ -276,7 +276,6 @@ private:
 
   std::unordered_map<Operation *, Value> inputOpToIFMValue;
 
-
   unsigned currentDesign = 1;
 
   void initProperties() {
@@ -338,7 +337,6 @@ private:
     connsOutToInMap.clear();
     fusedToUnfuseOutputMap.clear();
     inputOpToIFMValue.clear();
-
   }
 
   std::map<std::string, uint64_t> getLayerStatsMap(Operation *op) {
@@ -384,8 +382,7 @@ private:
 
   template <class T>
   void fillOther(T &op, Value v, JsonPropertiesBuilder &props) {
-    auto volume_bytes =
-        props.appendTypeInfo("Attributes.Other", v.getType());
+    auto volume_bytes = props.appendTypeInfo("Attributes.Other", v.getType());
     props.appendStorageAttr(op, volume_bytes);
   }
 
@@ -469,17 +466,16 @@ private:
     // note that the shape originally was written out as ?o?c?h?w,
     // now it's ?x?x?x? like everywhere else.
     auto bytes = 0;
-    bytes += props.appendTypeInfo("Attributes.Weights", getWeight(op).getType());
+    bytes +=
+        props.appendTypeInfo("Attributes.Weights", getWeight(op).getType());
     bytes += props.appendTypeInfo("Attributes.Bias", getBias(op).getType());
-
 
     Torch::BaseTensorType weightTy =
         getWeight(op).getType().template cast<Torch::BaseTensorType>();
 
     // h,w
-    std::string kernel_shape =
-        std::to_string( weightTy.getSizes()[2]) 
-        + "," + std::to_string( weightTy.getSizes()[3]);
+    std::string kernel_shape = std::to_string(weightTy.getSizes()[2]) + "," +
+                               std::to_string(weightTy.getSizes()[3]);
 
     props.append("Attributes.kernel shape", kernel_shape);
     props.appendIntList("Attributes.padding", getConvPadding(op));
@@ -597,7 +593,8 @@ private:
   template <typename LinearOpType>
   void fillPropertiesLinearOp(LinearOpType &op, JsonPropertiesBuilder &&props) {
     auto bytes = 0;
-    bytes += props.appendTypeInfo("Attributes.Weights", getWeight(op).getType());
+    bytes +=
+        props.appendTypeInfo("Attributes.Weights", getWeight(op).getType());
     bytes += props.appendTypeInfo("Attributes.Bias", getBias(op).getType());
     props.appendStorageAttr(op, bytes);
   }
@@ -656,10 +653,10 @@ private:
     bytes +=
         props.appendTypeInfo("Attributes.Weights", getBnWeight(op).getType());
     bytes += props.appendTypeInfo("Attributes.Bias", getBnBias(op).getType());
-    bytes +=
-        props.appendTypeInfo("Attributes.Weights", getRunningMean(op).getType());
-    bytes +=
-        props.appendTypeInfo("Attributes.Variance", getRunningVar(op).getType());
+    bytes += props.appendTypeInfo("Attributes.Weights",
+                                  getRunningMean(op).getType());
+    bytes += props.appendTypeInfo("Attributes.Variance",
+                                  getRunningVar(op).getType());
     props.appendStorageAttr(op, bytes);
 
     props.appendFloatValue("Attributes.eps", getEps(op));
@@ -693,7 +690,6 @@ private:
         op, props.nextFusedOp("aten.convolution"));
     storage += fillPropertiesBatchNormOp<xten::Conv2dBatchNormReLUOp>(
         op, props.nextFusedOp("torch.aten.batch_norm"));
-
 
     props.appendStorageAttr(op, storage);
   }
@@ -965,7 +961,6 @@ private:
         type_str = typeStr(sizeResultTy);
         bytes_str = std::to_string(total_bytes(sizeResultTy, total_inputs));
       }
-
 
       portPropsObject["name"] = port_name_prefix + ".Tensor";
       portPropsObject["tooltip"] = "Dimensions of " + port_type_str;


### PR DESCRIPTION
- Torch constants have been renamed
- most of the changes are from clang-format. Feel free to request a revert on them. They were accidental