### PR TITLE
Improve handling if operations lack the layer_name attribute

### DIFF
--- a/lib/Conversion/ATenToXTen.cpp.inc
+++ b/lib/Conversion/ATenToXTen.cpp.inc
@@ -6,15 +6,6 @@
 // operations. Therefore, it was not possible to capture this attribute in the
 // table gen file.
 
-void setLayerNameAttr(Operation *source, Operation *target) {
-  if (source == nullptr || target == nullptr)
-    return;
-  if (source->hasAttr("layer_name"))
-    target->setAttr("layer_name", source->getAttr("layer_name"));
-  else
-    source->emitError("The operation is expected to have layer_name attribute");
-}
-
 static ::mlir::LogicalResult static_dag_matcher_0(
     ::mlir::PatternRewriter &rewriter, ::mlir::Operation *op0,
     ::llvm::SmallVector<::mlir::Operation *, 4> &tblgen_ops,
@@ -189,7 +180,8 @@ struct GeneratedConvert0 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_Conv2dOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_Conv2dOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -268,7 +260,8 @@ struct GeneratedConvert1 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dReLUOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dReLUOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -351,7 +344,8 @@ struct GeneratedConvert2 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dLReLUOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dLReLUOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -440,7 +434,8 @@ struct GeneratedConvert3 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dLReLUPadOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dLReLUPadOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -526,7 +521,8 @@ struct GeneratedConvert4 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dReLUPadOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dReLUPadOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -624,7 +620,8 @@ struct GeneratedConvert5 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dLReLUMaxPoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dLReLUMaxPoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -739,7 +736,8 @@ struct GeneratedConvert6 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dLReLUPadMaxPoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dLReLUPadMaxPoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -835,7 +833,8 @@ struct GeneratedConvert7 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dReLUMaxPoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dReLUMaxPoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -947,7 +946,8 @@ struct GeneratedConvert8 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dReLUPadMaxPoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dReLUPadMaxPoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1069,7 +1069,8 @@ struct GeneratedConvert9 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dBatchNormReLUOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dBatchNormReLUOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1193,7 +1194,8 @@ struct GeneratedConvert10 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_AddConstantOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_AddConstantOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1247,7 +1249,8 @@ struct GeneratedConvert11 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_MMOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_MMOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1303,7 +1306,8 @@ struct GeneratedConvert12 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_MulOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_MulOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1361,7 +1365,8 @@ struct GeneratedConvert13 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_AddOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_AddOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1420,7 +1425,8 @@ struct GeneratedConvert14 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_SoftmaxOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_SoftmaxOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1486,7 +1492,8 @@ struct GeneratedConvert15 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_GlobalAveragePool2D_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_GlobalAveragePool2D_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1660,7 +1667,8 @@ struct GeneratedConvert16 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_GlobalAveragePool2D_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_GlobalAveragePool2D_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1722,7 +1730,8 @@ struct GeneratedConvert17 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_GlobalAveragePool2D_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_GlobalAveragePool2D_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1790,7 +1799,8 @@ struct GeneratedConvert18 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(op0, tblgen_LinearOp_0);
+    if (setLayerNameAttr(rewriter, op0, tblgen_LinearOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -1847,7 +1857,8 @@ struct GeneratedConvert19 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);                                              
     }                                                                               
                                                                                     
-    setLayerNameAttr(tblgen_ops.back(), tblgen_LinearReluOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_LinearReluOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);                                    
     return ::mlir::success();                                                       

--- a/lib/Conversion/XTenFusions.cpp.inc
+++ b/lib/Conversion/XTenFusions.cpp.inc
@@ -6,16 +6,6 @@
 // operations. Therefore, it was not possible to capture this attribute in the
 // table gen file.
 
-void setLayerNameAttr(Operation *source, Operation *target) {
-  const std::string attrName = "layer_name";
-  if (source == nullptr || target == nullptr)
-    return;
-  if (source->hasAttr(attrName))
-    target->setAttr(attrName, source->getAttr(attrName));
-  else
-    source->emitError("The operation is expected to have layer_name attribute");
-}
-
 static ::mlir::LogicalResult static_dag_matcher_0(
     ::mlir::PatternRewriter &rewriter, ::mlir::Operation *op0,
     ::llvm::SmallVector<::mlir::Operation *, 4> &tblgen_ops,
@@ -181,7 +171,8 @@ struct GeneratedConvert0 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops[1], tblgen_Conv2dTensorAddOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops[1], tblgen_Conv2dTensorAddOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -283,7 +274,8 @@ struct GeneratedConvert1 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops[2], tblgen_Conv2dTensorAddOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops[2], tblgen_Conv2dTensorAddOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -366,7 +358,8 @@ struct GeneratedConvert2 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dTensorAddOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -449,7 +442,8 @@ struct GeneratedConvert3 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dTensorAddOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -531,7 +525,8 @@ struct GeneratedConvert4 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dTensorAddReLUOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddReLUOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -617,7 +612,8 @@ struct GeneratedConvert5 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(), tblgen_Conv2dTensorAddLReLUOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddLReLUOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -700,8 +696,8 @@ struct GeneratedConvert6 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(),
-                     tblgen_Conv2dTensorAddGlobalAveragePoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddGlobalAveragePoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -798,8 +794,8 @@ struct GeneratedConvert7 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(),
-                     tblgen_Conv2dTensorAddReLUGlobalAveragePoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddReLUGlobalAveragePoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();
@@ -900,8 +896,8 @@ struct GeneratedConvert8 : public ::mlir::RewritePattern {
       tblgen_repl_values.push_back(v);
     }
 
-    setLayerNameAttr(tblgen_ops.back(),
-                     tblgen_Conv2dTensorAddLReLUGlobalAveragePoolOp_0);
+    if (setLayerNameAttr(rewriter, tblgen_ops.back(), tblgen_Conv2dTensorAddLReLUGlobalAveragePoolOp_0).failed())
+      return failure();
 
     rewriter.replaceOp(op0, tblgen_repl_values);
     return ::mlir::success();

--- a/test/Conversion/ATenToXTen/aten_linear_to_xten.mlir
+++ b/test/Conversion/ATenToXTen/aten_linear_to_xten.mlir
@@ -36,13 +36,13 @@ func.func @invalid_lowering(%arg0: !torch.vtensor<[3,4,2048],f32>, %arg1: !torch
 func.func @lowering_with_bias_optional(%arg0: !torch.vtensor<[1,2048],f32>, %arg1: !torch.vtensor<[1000,2048],f32>) -> !torch.vtensor<[1,1000],f32> attributes {input_names = ["x", "fc.weight", "fc.bias"], output_names = ["y"]} {
     %none = torch.constant.none
     %optional_tensor = torch.derefine %none: !torch.none to !torch.optional<tensor>
-    %0 = torch.aten.linear %arg0, %arg1, %optional_tensor : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.optional<tensor> -> !torch.vtensor<[1,1000],f32>
+    %0 = torch.aten.linear %arg0, %arg1, %optional_tensor {layer_name = "Gemm_0"} : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.optional<tensor> -> !torch.vtensor<[1,1000],f32>
     return %0 : !torch.vtensor<[1,1000],f32>
     
 // CHECK-LABEL: func.func @lowering_with_bias_optional
 // CHECK-NEXT:     %[[NONE:.+]] = torch.constant.none
 // CHECK-NEXT:     %[[OPTIONAL:.+]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<tensor>
-// CHECK-NEXT:     %[[R0:.+]] = "xten.linear"(%arg0, %arg1, %[[OPTIONAL]]) : (!torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.optional<tensor>) -> !torch.vtensor<[1,1000],f32>
+// CHECK-NEXT:     %[[R0:.+]] = "xten.linear"(%arg0, %arg1, %[[OPTIONAL]]) {layer_name = "Gemm_0"} : (!torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.optional<tensor>) -> !torch.vtensor<[1,1000],f32>
 // CHECK-NEXT:     return %[[R0]] : !torch.vtensor<[1,1000],f32>
 // CHECK-NEXT:  }
 }
@@ -50,12 +50,12 @@ func.func @lowering_with_bias_optional(%arg0: !torch.vtensor<[1,2048],f32>, %arg
 // If we receive an none as a bias tensor we should just pass it along, similar to the other test cases
 func.func @lowering_with_bias_none(%arg0: !torch.vtensor<[1,2048],f32>, %arg1: !torch.vtensor<[1000,2048],f32>) -> !torch.vtensor<[1,1000],f32> attributes {input_names = ["x", "fc.weight", "fc.bias"], output_names = ["y"]} {
     %none = torch.constant.none
-    %0 = torch.aten.linear %arg0, %arg1, %none : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.none -> !torch.vtensor<[1,1000],f32>
+    %0 = torch.aten.linear %arg0, %arg1, %none {layer_name = "Gemm_0"} : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.none -> !torch.vtensor<[1,1000],f32>
     return %0 : !torch.vtensor<[1,1000],f32>
     
 // CHECK-LABEL: func.func @lowering_with_bias_none
 // CHECK-NEXT:     %[[NONE:.+]] = torch.constant.none
-// CHECK-NEXT:     %[[R0:.+]] = "xten.linear"(%arg0, %arg1, %[[NONE]]) : (!torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.none) -> !torch.vtensor<[1,1000],f32>
+// CHECK-NEXT:     %[[R0:.+]] = "xten.linear"(%arg0, %arg1, %[[NONE]]) {layer_name = "Gemm_0"} : (!torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.none) -> !torch.vtensor<[1,1000],f32>
 // CHECK-NEXT:     return %[[R0]] : !torch.vtensor<[1,1000],f32>
 // CHECK-NEXT:  }
 }


### PR DESCRIPTION
The name may not be available in the front end. Avoid failing, but make it clear if the attribute is not filled in on the final xten operations.