### PR TITLE
Allow building together with torch-mlir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,26 @@ link_directories(${PROJECT_BINARY_DIR}/../aie/lib/)
 
 add_definitions(${LLVM_DEFINITIONS})
 
+set(MLIR_XTEN_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(MLIR_XTEN_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+function(mlir_xten_target_includes target)
+  set(_dirs
+    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${MLIR_XTEN_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${MLIR_XTEN_BINARY_DIR}/include>
+  )
+  # In LLVM parlance, the actual target may just be an interface and may not
+  # be responsible for actually compiling anything. The corresponding obj.
+  # target, when present, is just used for compilation and does not
+  # contribute to the interface properties.
+  # TODO: Normalize this upstream.
+  target_include_directories(${target} PUBLIC ${_dirs})
+  if(TARGET obj.${target})
+    target_include_directories(obj.${target} PRIVATE ${_dirs})
+  endif()
+endfunction()
+
 add_custom_target(check-all)
 
 # Make sure we build the docs

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -26,4 +26,6 @@ LINK_COMPONENTS
 Core
 
 LINK_LIBS PUBLIC
+TorchMLIRTorchDialect
+TorchMLIRTorchConversionDialect
 )

--- a/lib/Dialect/XTen/IR/CMakeLists.txt
+++ b/lib/Dialect/XTen/IR/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-add_mlir_library(XTenDialect
+add_mlir_dialect_library(XTenDialect
   XTenDialect.cpp
   XTenOps.cpp
   XTenOpWrapper.cpp
@@ -18,4 +18,6 @@ add_mlir_library(XTenDialect
   MLIRIR
   MLIRPass
   MLIRTransforms
+  TorchMLIRTorchDialect
 )
+mlir_xten_target_includes(XTenDialect)

--- a/lib/Dialect/XTen/Transforms/CMakeLists.txt
+++ b/lib/Dialect/XTen/Transforms/CMakeLists.txt
@@ -20,4 +20,5 @@ add_mlir_library(XTenTransforms
   MLIRIR
   MLIRPass
   MLIRTransforms
+  TorchMLIRTorchDialect
 )

--- a/lib/Dialect/XTenNN/IR/CMakeLists.txt
+++ b/lib/Dialect/XTenNN/IR/CMakeLists.txt
@@ -18,3 +18,4 @@ add_mlir_dialect_library(XTenNNDialect
   MLIRTransforms
   XTenNNInterfaces
 )
+mlir_xten_target_includes(XTenNNDialect)

--- a/lib/Transform/CMakeLists.txt
+++ b/lib/Transform/CMakeLists.txt
@@ -17,7 +17,9 @@ add_mlir_library(XTenTransformPasses
   DEPENDS
   MLIRXTenOpsIncGen
   XTenTransformIncGen
+  TorchMLIRTorchDialect
 
   LINK_LIBS
   XTenDialect
-  )
+  TorchMLIRTorchDialect
+)

--- a/lib/Util/CMakeLists.txt
+++ b/lib/Util/CMakeLists.txt
@@ -12,4 +12,5 @@ add_mlir_library(XTenUtil
   MLIRIR
   MLIRPass
   MLIRTransforms
+  TorchMLIRTorchDialect
 )


### PR DESCRIPTION
This does two things
1) Declare which libraries depend on TorchMLIRTorchDialect/TorchMLIRTorchConversionDialect so their header generation through tablegen is triggered before the library is compiled

2) Add proper target_include_directories on mlir-xten targets, so consumers of those libraries automatically have the correct include paths.