### PR TITLE
feat(sched): Keep concat producers in the order they appear.

### DIFF
--- a/lib/Transform/XTenMinimizeLiveTensors.cpp
+++ b/lib/Transform/XTenMinimizeLiveTensors.cpp
@@ -356,11 +356,16 @@ public:
       branches.push_back(opIt->second);
     }
 
-    std::sort(branches.begin(), branches.end(),
-              [](BranchRunning &aBranch, BranchRunning &bBranch) -> bool {
-                return (aBranch.maxRunning - aBranch.lastResults) >
-                       (bBranch.maxRunning - bBranch.lastResults);
-              });
+    // Concat producers should be ordered according to their operands
+    // (op0 before op1 before op2, etc.), so no need to sort them out.
+    if (!isConcatSubgraph(opInfo->op)) {
+      std::sort(branches.begin(), branches.end(),
+                [](BranchRunning &aBranch, BranchRunning &bBranch) -> bool {
+                  return (aBranch.maxRunning - aBranch.lastResults) >
+                         (bBranch.maxRunning - bBranch.lastResults);
+                });
+    }
+
     opInfo->orderedProducers.clear();
     for (BranchRunning const &branch : branches)
       opInfo->orderedProducers.push_back(branch.lastOp);

--- a/test/Transform/XTenMinimizeLiveTensors/incore_chain_subgraphs.mlir
+++ b/test/Transform/XTenMinimizeLiveTensors/incore_chain_subgraphs.mlir
@@ -96,39 +96,28 @@ func.func @multi_incore_chains_multiple_ifms_ofm(%arg0: tensor<1x4x224x224xf32>,
 
 // -----
 
-// CHECK-LABEL: func.func @multi_incore_chains_with_concat
+// CHECK-LABEL: func.func @incorechain_ops_with_concat
 // CHECK:     "InCoreChain_0"
 // CHECK:     "InCoreChain_1"
-// CHECK:     "Concat0"
-// CHECK:     "InCoreChain_3"
 // CHECK:     "InCoreChain_2"
-// CHECK:     "InCoreChain_5"
-// CHECK:     "InCoreChain_6"
-func.func @multi_incore_chains_with_concat(%arg0: tensor<1x4x224x224xf32>, %arg1: tensor<1x4x224x224xf32>, %arg2: tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32> attributes {input_names = ["global_input_0"], output_names = ["global_outout_0"]} {
+// CHECK:     "Concat0"
+func.func @incorechain_ops_with_concat(%arg0: tensor<1x4x224x224xf32>, %arg1: tensor<1x4x224x224xf32>, %arg2: tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32> attributes {input_names = ["global_input_0"], output_names = ["global_outout_0"]} {
   %0 = "tosa.const"() {value = dense<2.000000e-02> : tensor<64x4x7x7xf32>} : () -> tensor<64x4x7x7xf32>
   %1 = "tosa.const"() {value = dense<2.000000e-02> : tensor<64xf32>} : () -> tensor<64xf32>
   %2 = xten_nn.subgraph (%arg3 = %arg0: tensor<1x4x224x224xf32>, %arg4 = %0: tensor<64x4x7x7xf32>, %arg5 = %1: tensor<64xf32>, %arg6 = %arg2: tensor<1x64x112x112xf32>)  attributes {IfmOperands = [0 : index, 3 : index], LayerName = "InCoreChain_0", OfmShare = 3 : index, Reason = "InCoreChain"} {
     %7 = xten_nn.subgraph (%arg7 = %arg3: tensor<1x4x224x224xf32>, %arg8 = %arg4: tensor<64x4x7x7xf32>, %arg9 = %arg5: tensor<64xf32>)  attributes {LayerName = "Conv_1_0", Reason = "MllibKernel", compile_time_configurations = "Conv2D_ReLU", config_attrs = {act = "RELU", batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Conv2D", run_time_parameters = {act = 1 : i64, conv_type = [0, 3, 4], ksize = 7 : i64, stride_log2 = 1 : i64}, vectorization_granularity = "C8"} {
-      %10 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %10 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    %8 = xten_nn.subgraph (%arg7 = %arg3: tensor<1x4x224x224xf32>, %arg8 = %arg4: tensor<64x4x7x7xf32>, %arg9 = %arg5: tensor<64xf32>)  attributes {LayerName = "Conv_1_1", Reason = "MllibKernel", compile_time_configurations = "Conv2D_ReLU", config_attrs = {act = "RELU", batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Conv2D", run_time_parameters = {act = 1 : i64, conv_type = [0, 3, 4], ksize = 7 : i64, stride_log2 = 1 : i64}, vectorization_granularity = "C8"} {
-      %10 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %10 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    %9 = xten_nn.subgraph (%arg7 = %7: tensor<1x64x112x112xf32>, %arg8 = %arg6: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_1", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %10 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %10 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    xten_nn.output %9 : tensor<1x64x112x112xf32>
-  } -> tensor<1x64x112x112xf32>
-  %3 = xten_nn.subgraph (%arg3 = %2: tensor<1x64x112x112xf32>, %arg4 = %2: tensor<1x64x112x112xf32>)  attributes {IfmOperands = [0 : index, 1 : index], LayerName = "InCoreChain_1", Reason = "InCoreChain"} {
-    %7 = xten_nn.subgraph (%arg5 = %arg3: tensor<1x64x112x112xf32>, %arg6 = %arg4: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_2", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %8 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %8 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    xten_nn.output %7 : tensor<1x64x112x112xf32>
-  } -> tensor<1x64x112x112xf32>
+      %10 = tensor.empty() : tensor<1x4x224x224xf32>
+      xten_nn.output %10 : tensor<1x4x224x224xf32>
+    } -> tensor<1x4x224x224xf32>
+    xten_nn.output %7 : tensor<1x4x224x224xf32>
+  } -> tensor<1x4x224x224xf32>
+  %3 = xten_nn.subgraph (%arg3 = %arg1: tensor<1x4x224x224xf32>, %arg4 = %arg1: tensor<1x4x224x224xf32>)  attributes {IfmOperands = [0 : index, 1 : index], LayerName = "InCoreChain_1", Reason = "InCoreChain"} {
+    %7 = xten_nn.subgraph (%arg5 = %arg3: tensor<1x4x224x224xf32>, %arg6 = %arg4: tensor<1x4x224x224xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_2", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
+      %8 = tensor.empty() : tensor<1x4x64x64xf32>
+      xten_nn.output %8 : tensor<1x4x64x64xf32>
+    } -> tensor<1x4x64x64xf32>
+    xten_nn.output %7 : tensor<1x4x64x64xf32>
+  } -> tensor<1x4x64x64xf32>
   %4 = xten_nn.subgraph (%arg3 = %arg0: tensor<1x4x224x224xf32>, %arg4 = %0: tensor<64x4x7x7xf32>, %arg5 = %1: tensor<64xf32>, %arg6 = %arg2: tensor<1x64x112x112xf32>)  attributes {IfmOperands = [0 : index, 3 : index], LayerName = "InCoreChain_2", OfmShare = 3 : index, Reason = "InCoreChain"} {
     %7 = xten_nn.subgraph (%arg7 = %arg3: tensor<1x4x224x224xf32>, %arg8 = %arg4: tensor<64x4x7x7xf32>, %arg9 = %arg5: tensor<64xf32>)  attributes {LayerName = "Conv_2_0", Reason = "MllibKernel", compile_time_configurations = "Conv2D_ReLU", config_attrs = {act = "RELU", batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Conv2D", run_time_parameters = {act = 1 : i64, conv_type = [0, 3, 4], ksize = 7 : i64, stride_log2 = 1 : i64}, vectorization_granularity = "C8"} {
       %10 = tensor.empty() : tensor<1x64x112x112xf32>
@@ -144,38 +133,9 @@ func.func @multi_incore_chains_with_concat(%arg0: tensor<1x4x224x224xf32>, %arg1
     } -> tensor<1x64x112x112xf32>
     xten_nn.output %9 : tensor<1x64x112x112xf32>
   } -> tensor<1x64x112x112xf32>
-  %5 = xten_nn.subgraph (%arg3 = %2: tensor<1x64x112x112xf32>, %arg4 = %2: tensor<1x64x112x112xf32>)  attributes {IfmOperands = [0 : index, 1 : index], LayerName = "InCoreChain_3", Reason = "InCoreChain"} {
-    %7 = xten_nn.subgraph (%arg5 = %arg3: tensor<1x64x112x112xf32>, %arg6 = %arg4: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_4", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %8 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %8 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    xten_nn.output %7 : tensor<1x64x112x112xf32>
-  } -> tensor<1x64x112x112xf32>
-  %6 = xten_nn.subgraph (%arg1 = %2: tensor<1x64x112x112xf32>, %arg2 = %3: tensor<1x64x112x112xf32>)  attributes {LayerName = "Concat0", Reason = "PseudoOp", Op = "Concat", SourceOpAttrs = {axis = 1 : si64, onnx_node_name = "Concat_0", output_bitwidth = 8.000000e+00 : f32, output_narrow = 0 : si64, output_rounding_mode = "ROUND", output_scale_factor = 2.500000e-01 : f32, output_signed = 1 : si64}, argsConstMapping = {}, argsMapping = {"0" = 0 : index, "1" = 1 : index}} {
+  %5 = xten_nn.subgraph (%arg1 = %2: tensor<1x4x224x224xf32>, %arg2 = %3: tensor<1x4x64x64xf32>, %arg3 = %4: tensor<1x64x112x112xf32>)  attributes {LayerName = "Concat0", Reason = "PseudoOp", Op = "Concat", SourceOpAttrs = {axis = 1 : si64, onnx_node_name = "Concat_0", output_bitwidth = 8.000000e+00 : f32, output_narrow = 0 : si64, output_rounding_mode = "ROUND", output_scale_factor = 2.500000e-01 : f32, output_signed = 1 : si64}, argsConstMapping = {}, argsMapping = {"0" = 0 : index, "1" = 1 : index}} {
       %89 = tensor.empty() : tensor<1x64x112x112xf32>
     xten_nn.output %89 : tensor<1x64x112x112xf32>
   } -> tensor<1x64x112x112xf32>
-  %7 = xten_nn.subgraph (%arg3 = %4: tensor<1x64x112x112xf32>, %arg4 = %5: tensor<1x64x112x112xf32>, %arg5 = %0: tensor<64x4x7x7xf32>, %arg6 = %1: tensor<64xf32>, %arg7 = %arg0: tensor<1x4x224x224xf32>)  attributes {IfmOperands = [0 : index, 1 : index, 4 : index], LayerName = "InCoreChain_5", OfmShare = 0 : index, Reason = "InCoreChain"} {
-    %7 = xten_nn.subgraph (%arg8 = %arg3: tensor<1x64x112x112xf32>, %arg9 = %arg4: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_7", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %9 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %9 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    %8 = xten_nn.subgraph (%arg8 = %7: tensor<1x64x112x112xf32>, %arg9 = %arg4: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_8", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %9 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %9 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    xten_nn.output %8 : tensor<1x64x112x112xf32>
-  } -> tensor<1x64x112x112xf32>
-  %8 = xten_nn.subgraph (%arg3 = %6: tensor<1x64x112x112xf32>, %arg4 = %7: tensor<1x64x112x112xf32>, %arg5 = %0: tensor<64x4x7x7xf32>, %arg6 = %1: tensor<64xf32>, %arg7 = %arg0: tensor<1x4x224x224xf32>)  attributes {IfmOperands = [0 : index, 1 : index, 4 : index], LayerName = "InCoreChain_6", OfmShare = 0 : index, Reason = "InCoreChain"} {
-    %7 = xten_nn.subgraph (%arg8 = %arg3: tensor<1x64x112x112xf32>, %arg9 = %arg4: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_9", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %9 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %9 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    %8 = xten_nn.subgraph (%arg8 = %7: tensor<1x64x112x112xf32>, %arg9 = %arg4: tensor<1x64x112x112xf32>)  attributes {ChainedWith = "Conv_7", LayerName = "Add_10", Reason = "MllibKernel", compile_time_configurations = "Add2d", config_attrs = {batch_size = 1 : i64}, current_data_format = "NCHW", data_format = "HCWN", mllib_ops = "Add2d", run_time_parameters = {act = 1 : i64, batch_log2 = 0 : i64}, vectorization_granularity = "C8"} {
-      %9 = tensor.empty() : tensor<1x64x112x112xf32>
-      xten_nn.output %9 : tensor<1x64x112x112xf32>
-    } -> tensor<1x64x112x112xf32>
-    xten_nn.output %8 : tensor<1x64x112x112xf32>
-  } -> tensor<1x64x112x112xf32>
-  return %8 : tensor<1x64x112x112xf32>
+  return %5 : tensor<1x64x112x112xf32>
 }


### PR DESCRIPTION
Concat producers should be kept in the order they appear in the list of operands. Thus, there is no need to reorder them. This PR handles this case.