### PR TITLE
test(CanonicalizePass): fix failing tests by updating references

### DIFF
--- a/test/Dialect/XTenNN/Transform/CanonicalizePass/remove_qdq_between_concats.mlir
+++ b/test/Dialect/XTenNN/Transform/CanonicalizePass/remove_qdq_between_concats.mlir
@@ -111,9 +111,8 @@ func.func @foldable_concats(%arg0: tensor<1x1x7x7xf32>) -> tensor<1x4x7x7xf32> {
 
 // CHECK-LABEL:   func.func @foldable_concats(
 // CHECK-SAME:                                %[[VAL_0:.*]]: tensor<1x1x7x7xf32>) -> tensor<1x4x7x7xf32> {
-// CHECK:           %[[VAL_1:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x2x7x7xf32>
-// CHECK:           %[[VAL_2:.*]] = "tosa.concat"(%[[VAL_1]], %[[VAL_1]]) {axis = 1 : i64} : (tensor<1x2x7x7xf32>, tensor<1x2x7x7xf32>) -> tensor<1x4x7x7xf32>
-// CHECK:           return %[[VAL_2]] : tensor<1x4x7x7xf32>
+// CHECK:           %[[VAL_1:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]], %[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x4x7x7xf32>
+// CHECK:           return %[[VAL_1]] : tensor<1x4x7x7xf32>
 // CHECK:         }
 
 // SANE-LABEL:   func.func @foldable_concats(
@@ -138,10 +137,9 @@ func.func @multiple_foldable_user_concats(%arg0: tensor<1x1x7x7xf32>) -> (tensor
 
 // CHECK-LABEL:   func.func @multiple_foldable_user_concats(
 // CHECK-SAME:                                              %[[VAL_0:.*]]: tensor<1x1x7x7xf32>) -> (tensor<1x4x7x7xf32>, tensor<1x4x7x7xf32>) {
-// CHECK:           %[[VAL_1:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x2x7x7xf32>
-// CHECK:           %[[VAL_2:.*]] = "tosa.concat"(%[[VAL_1]], %[[VAL_1]]) {axis = 1 : i64} : (tensor<1x2x7x7xf32>, tensor<1x2x7x7xf32>) -> tensor<1x4x7x7xf32>
-// CHECK:           %[[VAL_3:.*]] = "tosa.concat"(%[[VAL_1]], %[[VAL_1]]) {axis = 1 : i64} : (tensor<1x2x7x7xf32>, tensor<1x2x7x7xf32>) -> tensor<1x4x7x7xf32>
-// CHECK:           return %[[VAL_2]], %[[VAL_3]] : tensor<1x4x7x7xf32>, tensor<1x4x7x7xf32>
+// CHECK:           %[[VAL_1:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]], %[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x4x7x7xf32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]], %[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x4x7x7xf32>
+// CHECK:           return %[[VAL_1]], %[[VAL_2]] : tensor<1x4x7x7xf32>, tensor<1x4x7x7xf32>
 // CHECK:         }
 
 // SANE-LABEL:   func.func @multiple_foldable_user_concats(
@@ -170,7 +168,7 @@ func.func @partially_foldable_user_concats(%arg0: tensor<1x1x7x7xf32>) -> (tenso
 // CHECK:           %[[VAL_1:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x2x7x7xf32>
 // CHECK:           %[[VAL_2:.*]] = xten_nn.quantize(%[[VAL_1]] : tensor<1x2x7x7xf32>) {shift = -3 : si32} -> tensor<1x2x7x7xsi8>
 // CHECK:           %[[VAL_3:.*]] = xten_nn.dequantize(%[[VAL_2]] : tensor<1x2x7x7xsi8>) {shift = -3 : si32} -> tensor<1x2x7x7xf32>
-// CHECK:           %[[VAL_4:.*]] = "tosa.concat"(%[[VAL_1]], %[[VAL_1]]) {axis = 1 : i64} : (tensor<1x2x7x7xf32>, tensor<1x2x7x7xf32>) -> tensor<1x4x7x7xf32>
+// CHECK:           %[[VAL_4:.*]] = "tosa.concat"(%[[VAL_0]], %[[VAL_0]], %[[VAL_0]], %[[VAL_0]]) {axis = 1 : i64} : (tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>, tensor<1x1x7x7xf32>) -> tensor<1x4x7x7xf32>
 // CHECK:           %[[VAL_5:.*]] = "tosa.concat"(%[[VAL_3]], %[[VAL_3]]) {axis = 0 : i64} : (tensor<1x2x7x7xf32>, tensor<1x2x7x7xf32>) -> tensor<2x2x7x7xf32>
 // CHECK:           return %[[VAL_4]], %[[VAL_5]] : tensor<1x4x7x7xf32>, tensor<2x2x7x7xf32>
 // CHECK:         }


### PR DESCRIPTION
As the concat folding is now implemented as an actual fold, instead of a pattern, this is now getting applied to this test as well. This must land once the LLVM PR lands as well:

- [x] https://github.com/Xilinx/llvm-project/pull/34