### PR TITLE
[FXML-2131] Move Constant Scale Factor to Rhs of Mul

### DIFF
--- a/lib/Conversion/TosaToXTenNN.cpp
+++ b/lib/Conversion/TosaToXTenNN.cpp
@@ -9,11 +9,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
-#include "mlir/IR/Matchers.h"
-#include "mlir/Transforms/CommutativityUtils.h"
 #include "xten/Conversion/TosaToXTenNNPass.h"
 #include "xten/Dialect/XTenNN/IR/XTenNNOps.h"
 
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/CommutativityUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace mlir;

--- a/lib/Conversion/TosaToXTenNN.cpp
+++ b/lib/Conversion/TosaToXTenNN.cpp
@@ -50,7 +50,7 @@ std::optional<int32_t> getLog2Value(float value) {
 }
 
 /// Matcher pattern that matches only if the constant float is a power-of-two
-/// value. Meaning, when log2(value) is applied we get a whole integer.
+/// value. Meaning, when log2(value) is applied, we get a whole integer.
 struct ConstantFloatLog2Binder {
   /// Contains the log2() of the float value if matched
   IntegerAttr::ValueType *bindValue;
@@ -202,6 +202,16 @@ public:
       return rewriter.notifyMatchFailure(
           dequantizeMulOp.getLoc(),
           "i/o shape cannot change when multiplying due to broadcasting.");
+    }
+
+    // Attempt to convert the scale factors to a log2 base. And ensure that both
+    // are equal. The quantization factor being the negation of the
+    // dequantization factor
+    if (quantizeShift.getSExtValue() + dequantizeShift.getSExtValue() != 0) {
+      return rewriter.notifyMatchFailure(
+          dequantizeMulOp.getLoc(),
+          "expected constants of both multiplications to be "
+          "equal and power-of-two values.");
     }
 
     // Sum the shifts of the quantize, dequantize and update the operations

--- a/lib/Conversion/TosaToXTenNN.cpp
+++ b/lib/Conversion/TosaToXTenNN.cpp
@@ -49,6 +49,34 @@ std::optional<int32_t> getLog2Value(float value) {
   return (int32_t)integerPart;
 }
 
+/// Matcher pattern that matches only if the constant float is a power-of-two
+/// value. Meaning, when log2(value) is applied we get a whole integer.
+struct ConstantFloatLog2Binder {
+  IntegerAttr::ValueType *bindValue;
+
+  /// Creates a matcher instance that binds the value to bv if match succeeds.
+  ConstantFloatLog2Binder(IntegerAttr::ValueType *bv) : bindValue(bv) {}
+
+  bool match(Operation *op) {
+    FloatAttr::ValueType value((float)0.0);
+    if (!detail::constant_float_op_binder(&value).match(op))
+      return false;
+    std::optional<int32_t> log2value = getLog2Value(value.convertToFloat());
+    if (log2value.has_value()) {
+      *bindValue = IntegerAttr::ValueType(32, log2value.value(), true);
+      return true;
+    }
+    return false;
+  }
+};
+
+/// Helper function to construct the matcher similar to the other m_* matcher
+/// functions.
+inline ConstantFloatLog2Binder
+mConstantFloatLog2(IntegerAttr::ValueType *bindValue) {
+  return {bindValue};
+}
+
 /// Checks that operand(0) and the result(0) have the same type.
 ///
 /// Used to check that broadcasting did not occur, for example, on
@@ -213,6 +241,46 @@ public:
   }
 };
 
+/// Moves the scale factor to the RHS for a MulOp. We assume the scale factor is
+/// a single value which is a power-of-two integer.
+class MoveScalarTensorToRHSOfMul : public OpRewritePattern<tosa::MulOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tosa::MulOp mulOp,
+                                PatternRewriter &rewriter) const override {
+    if (!m_Op<tosa::MulOp>(m_Constant(), m_Constant()).match(mulOp)) {
+      return rewriter.notifyMatchFailure(
+          mulOp.getLoc(),
+          "only reorganize operands on muls with two constants");
+    }
+
+    IntegerAttr::ValueType lhsValue;
+    if (!mConstantFloatLog2(&lhsValue).match(
+            mulOp->getOperand(0).getDefiningOp())) {
+      return rewriter.notifyMatchFailure(
+          mulOp.getLoc(), "left-hand operand must be a splat tensor "
+                          "with log2 base value.");
+    }
+
+    IntegerAttr::ValueType rhsValue;
+    if (mConstantFloatLog2(&rhsValue).match(
+            mulOp->getOperand(1).getDefiningOp())) {
+      return rewriter.notifyMatchFailure(
+          mulOp.getLoc(), "right-hand side is also a log2 base value.");
+    }
+
+    // Rearrange the operands so the splat tensor is on the RHS. Our QDQ nodes
+    // will also appear on constants and these constants will be multipled by
+    // scalar floats
+    rewriter.replaceOpWithNewOp<tosa::MulOp>(
+        mulOp, mulOp->getResult(0).getType(), mulOp->getOperand(1),
+        mulOp->getOperand(0), mulOp.getShift());
+
+    return success();
+  }
+};
+
 class TosaToXTenNNPass
     : public xilinx::xten::TOSAToXTenNNBase<TosaToXTenNNPass> {
 public:
@@ -224,7 +292,9 @@ public:
     // Ensures constants on the add, mul, sub are on the RHS
     populateCommutativityUtilsPatterns(patterns);
     // Patterns for finding the QDQ and folding MULs.
-    patterns.insert<CastsToQDQOps, FoldMulsToQDQOps>(context);
+    patterns
+        .insert<MoveScalarTensorToRHSOfMul, CastsToQDQOps, FoldMulsToQDQOps>(
+            context);
 
     FrozenRewritePatternSet frozenSetOfPatterns(std::move(patterns));
     if (failed(applyPatternsAndFoldGreedily(module, frozenSetOfPatterns))) {

--- a/lib/Conversion/TosaToXTenNN.cpp
+++ b/lib/Conversion/TosaToXTenNN.cpp
@@ -78,9 +78,10 @@ struct ConstantFloatLog2Binder {
 };
 
 /// Helper function to construct the matcher similar to the other m_* matcher
-/// functions.
+/// functions. Use the m_* naming style to match the orignal style. Currently,
+/// mlir-xten does not have a clang-tidy configuration.
 inline ConstantFloatLog2Binder
-mConstantFloatLog2(IntegerAttr::ValueType *bindValue) {
+m_ConstantFloatLog2(IntegerAttr::ValueType *bindValue) { // NOLINT
   return {bindValue};
 }
 
@@ -171,7 +172,7 @@ public:
     APInt quantizeShift(32, 0, true);
     auto isQDQPattern = m_Op<amd::xten_nn::DequantizeOp>(
         m_Op<amd::xten_nn::QuantizeOp>(m_Op<tosa::MulOp>(
-            matchers::m_Any(), mConstantFloatLog2(&quantizeShift))));
+            matchers::m_Any(), m_ConstantFloatLog2(&quantizeShift))));
     if (!dequantizeOp || !isQDQPattern.match(dequantizeOp)) {
       return rewriter.notifyMatchFailure(dequantizeMulOp->getLoc(),
                                          "expected mul->q->dq->mul pattern.");
@@ -179,7 +180,7 @@ public:
 
     // The multiplication should have only a single constant value
     APInt dequantizeShift(32, 0, true);
-    if (!mConstantFloatLog2(&dequantizeShift)
+    if (!m_ConstantFloatLog2(&dequantizeShift)
              .match(dequantizeMulOp.getOperand(1).getDefiningOp())) {
       return rewriter.notifyMatchFailure(dequantizeMulOp.getOperand(1).getLoc(),
                                          "expected to be a constant.");
@@ -255,7 +256,7 @@ public:
     }
 
     IntegerAttr::ValueType lhsValue;
-    if (!mConstantFloatLog2(&lhsValue).match(
+    if (!m_ConstantFloatLog2(&lhsValue).match(
             mulOp->getOperand(0).getDefiningOp())) {
       return rewriter.notifyMatchFailure(
           mulOp.getLoc(), "left-hand operand must be a splat tensor "
@@ -263,7 +264,7 @@ public:
     }
 
     IntegerAttr::ValueType rhsValue;
-    if (mConstantFloatLog2(&rhsValue).match(
+    if (m_ConstantFloatLog2(&rhsValue).match(
             mulOp->getOperand(1).getDefiningOp())) {
       return rewriter.notifyMatchFailure(
           mulOp.getLoc(), "right-hand side is also a log2 base value.");

--- a/test/Conversion/TosaToXTenNN/quantization.mlir
+++ b/test/Conversion/TosaToXTenNN/quantization.mlir
@@ -334,3 +334,57 @@ module attributes {} {
     return %5 : tensor<1x3x4x4xf32>
   }
 }
+
+// --
+
+module attributes {} {
+// CHECK-LABEL:     func.func @sort_mul_operands_on_constants() -> tensor<1x3x4x4xf32> {
+// CHECK:             %[[VAL_0:.*]] = "tosa.const"() {value = dense<1.280000e+02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+// CHECK:             %[[VAL_1:.*]] = "tosa.const"() {value = dense<2.000000e-02> : tensor<1x3x4x4xf32>} : () -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_2:.*]] = "tosa.mul"(%[[VAL_1]], %[[VAL_0]]) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return %[[VAL_2]] : tensor<1x3x4x4xf32>
+// CHECK:           }
+ func.func @sort_mul_operands_on_constants() -> tensor<1x3x4x4xf32> {
+    %0 = "tosa.const"() {value = dense<1.280000e+02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %1 = "tosa.const"() {value = dense<2.000000e-02> : tensor<1x3x4x4xf32>} : () -> tensor<1x3x4x4xf32> 
+    %2 = "tosa.mul"(%0, %1) {shift = 0 : i32} : (tensor<1x1x1x1xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+    return %2 : tensor<1x3x4x4xf32>
+  }
+}
+
+// --
+
+module attributes {} {
+// CHECK-LABEL:     func.func @sort_mul_operands_on_scalar_constants() -> tensor<3xf32> {
+// CHECK:             %[[VAL_0:.*]] = "tosa.const"() {value = dense<1.280000e+02> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK:             %[[VAL_1:.*]] = "tosa.const"() {value = dense<2.000000e-02> : tensor<3xf32>} : () -> tensor<3xf32>
+// CHECK:             %[[VAL_2:.*]] = "tosa.mul"(%[[VAL_1]], %[[VAL_0]]) {shift = 0 : i32} : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
+// CHECK:             return %[[VAL_2]] : tensor<3xf32>
+// CHECK:           }
+ func.func @sort_mul_operands_on_scalar_constants() -> tensor<3xf32> {
+    %0 = "tosa.const"() {value = dense<1.280000e+02> : tensor<1xf32>} : () -> tensor<1xf32>
+    %1 = "tosa.const"() {value = dense<2.000000e-02> : tensor<3xf32>} : () -> tensor<3xf32> 
+    %2 = "tosa.mul"(%0, %1) {shift = 0 : i32} : (tensor<1xf32>, tensor<3xf32>) -> tensor<3xf32>
+    return %2 : tensor<3xf32>
+  }
+}
+
+// --
+
+module attributes {} {
+// CHECK-LABEL:     func.func @sort_mul_operands_both_log2() -> tensor<3xf32> {
+// CHECK:             %[[VAL_0:.*]] = "tosa.const"() {value = dense<1.280000e+02> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK:             %[[VAL_1:.*]] = "tosa.const"() {value = dense<6.400000e+01> : tensor<3xf32>} : () -> tensor<3xf32>
+// CHECK:             %[[VAL_2:.*]] = "tosa.mul"(%[[VAL_0]], %[[VAL_1]]) {shift = 0 : i32} : (tensor<1xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:             return %[[VAL_2]] : tensor<3xf32>
+// CHECK:           }
+ func.func @sort_mul_operands_both_log2() -> tensor<3xf32> {
+    // Both floating point constants are power-of-two values when log2 is
+    // applied they both are converted to whole integers. Therefore, the
+    // sorting pattern should do nothing.
+    %0 = "tosa.const"() {value = dense<1.280000e+02> : tensor<1xf32>} : () -> tensor<1xf32>
+    %1 = "tosa.const"() {value = dense<6.400000e+01> : tensor<3xf32>} : () -> tensor<3xf32> 
+    %2 = "tosa.mul"(%0, %1) {shift = 0 : i32} : (tensor<1xf32>, tensor<3xf32>) -> tensor<3xf32>
+    return %2 : tensor<3xf32>
+  }
+}

--- a/test/Conversion/TosaToXTenNN/quantization.mlir
+++ b/test/Conversion/TosaToXTenNN/quantization.mlir
@@ -388,3 +388,24 @@ module attributes {} {
     return %2 : tensor<3xf32>
   }
 }
+
+// --
+
+module attributes {} {
+// CHECK-LABEL:     func.func @fold_after_sort_on_mul() -> tensor<1x3x4x4xf32> {
+// CHECK:             %[[VAL_0:.*]] = "tosa.const"() {value = dense<2.000000e-02> : tensor<1x3x4x4xf32>} : () -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_1:.*]] = xten_nn.quantize(%[[VAL_0]] : tensor<1x3x4x4xf32>) {shift = -7 : si32} -> tensor<1x3x4x4xsi8>
+// CHECK:             %[[VAL_2:.*]] = xten_nn.dequantize(%[[VAL_1]] : tensor<1x3x4x4xsi8>) {shift = -7 : si32} -> tensor<1x3x4x4xf32>
+// CHECK:             return %[[VAL_2]] : tensor<1x3x4x4xf32>
+// CHECK:           }
+ func.func @fold_after_sort_on_mul() -> tensor<1x3x4x4xf32> {
+    %0 = "tosa.const"() {value = dense<1.280000e+02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32> 
+    %1 = "tosa.const"() {value = dense<7.812500e-03> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32> 
+    %2 = "tosa.const"() {value = dense<2.000000e-02> : tensor<1x3x4x4xf32>} : () -> tensor<1x3x4x4xf32> 
+    %3 = "tosa.mul"(%0, %2) {shift = 0 : i32} : (tensor<1x1x1x1xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> 
+    %4 = xten_nn.quantize(%3 : tensor<1x3x4x4xf32>) {shift = 0 : si32} -> tensor<1x3x4x4xsi8> 
+    %5 = xten_nn.dequantize(%4 : tensor<1x3x4x4xsi8>) {shift = 0 : si32} -> tensor<1x3x4x4xf32> 
+    %6 = "tosa.mul"(%5, %1) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32> 
+    return %6 : tensor<1x3x4x4xf32>
+  }
+}


### PR DESCRIPTION
Our original matching patterns assume the scale factor constant is on the RHS of the mul for us to fold them into the quantize and dequantize operations.

In real world examples this does not always hold, especially for quantization of weights and biases where the scale factor can appear on the LHS of the operation. As both inputs are constants, the CommunativeSort utility does nothing.

Here I introduce a specialized sorting which only rearranges the operands of a `tosa::MulOp` if the LHS is a single value (splat) tensor whose value is a power-of-two. 

As this is a specialized pass only unique to our XTenNN operations, I have decided to place it here. 

A follow-up PR will introduce the folding of casts (quantize) into these weights, but for now this enables complete conversion to XTenNN quantization operations. The follow-up will utilize the new folding functions for `tosa::MulOp` that have been introduce on our fork of `llvm-project` in the `quant` branch. 