### PR TITLE
[FXML-2313] Remove ConstantLike Trait

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -148,11 +148,18 @@ def XTenNN_DequantizeOp: XTenNN_Op<"dequantize", [
   let assemblyFormat = [{ `(`$input `:` type($input)`)` attr-dict `->` type($output) }];
 }
 
-def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [ ConstantLike,
+def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
             Pure]> {
   let summary = "Loads a constant from an external h5 file to a const operator.";
   let description = [{
     Looks into `file` for `key`, retrieves the value and replace this operator by the loaded value.
+
+    Unfortunately, this operation cannot be carry the ConstantLike trait as a Fold operation
+    is required to be implemented for constants. For this particular operation we cannot return
+    a sensible value as other dialect constants do since the value is stored within a file.
+
+    This implementation follows closely to what `ml_program.global_load_const` implements. As it too
+    does not implement the ConstantLike trait.
   }];
   let arguments = (ins 
     StrAttr:$key,

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -154,7 +154,7 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
   let description = [{
     Looks into `file` for `key`, retrieves the value and replace this operator by the loaded value.
 
-    Unfortunately, this operation cannot be carry the ConstantLike trait as a Fold operation
+    Unfortunately, this operation cannot carry the ConstantLike trait as a Fold operation
     is required to be implemented for constants. For this particular operation we cannot return
     a sensible value as other dialect constants do since the value is stored within a file.
 


### PR DESCRIPTION
Unfortunately we cannot implement a fold interface for this operation as it cannot sensible return a value for the constant. 

Returning an empty attribute also causes a failure. For now we will follow the implementation that `ml_program` also implements, but leaving the ConstantLike attribute out. 