### PR TITLE
fix(TosaToXTenNN): fix use check on Mul->Q->DQ->Mul

### DIFF
--- a/lib/Conversion/TosaToXTenNN.cpp
+++ b/lib/Conversion/TosaToXTenNN.cpp
@@ -115,9 +115,9 @@ public:
                                          "expected cast -> cast pattern.");
     }
 
-    if (!quantizeOp->hasOneUse() || !castOp->hasOneUse()) {
+    if (!quantizeOp->hasOneUse()) {
       return rewriter.notifyMatchFailure(quantizeOp.getLoc(),
-                                         "expected the quantize and dequantize "
+                                         "expected the quantize "
                                          "operation to have a single use.");
     }
 
@@ -192,7 +192,8 @@ public:
     // Make sure the quantize multiplication belongs only to the QDQ operation
     // and are used by no one else.
     auto *quantizeMulOp = quantizeOp->getOperand(0).getDefiningOp();
-    if (!quantizeMulOp->hasOneUse()) {
+    if (!quantizeMulOp->hasOneUse() || !quantizeOp->hasOneUse() ||
+        !dequantizeOp->hasOneUse()) {
       return rewriter.notifyMatchFailure(
           dequantizeMulOp->getLoc(),
           "the quantize multiplication can have only a single user.");

--- a/test/Conversion/TosaToXTenNN/quantization.mlir
+++ b/test/Conversion/TosaToXTenNN/quantization.mlir
@@ -265,6 +265,86 @@ module attributes {} {
 // --
 
 module attributes {} {
+// CHECK-LABEL:     func.func @multiple_dq_uses(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: tensor<1x3x4x4xf32>,
+// CHECK-SAME:                                  %[[VAL_1:.*]]: tensor<1x3x4x4xf32>) -> (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) {
+// CHECK:             %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             %[[VAL_3:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             %[[VAL_4:.*]] = "tosa.mul"(%[[VAL_0]], %[[VAL_2]]) <{shift = 0 : i32}> : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_5:.*]] = "tosa.cast"(%[[VAL_4]]) : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
+// CHECK:             %[[VAL_6:.*]] = "tosa.cast"(%[[VAL_5]]) : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_7:.*]] = "tosa.mul"(%[[VAL_6]], %[[VAL_3]]) <{shift = 0 : i32}> : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_8:.*]] = "tosa.add"(%[[VAL_1]], %[[VAL_6]]) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return %[[VAL_7]], %[[VAL_8]] : tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>
+// CHECK:           }
+  func.func @multiple_dq_uses(%arg0: tensor<1x3x4x4xf32>, %arg1: tensor<1x3x4x4xf32>) -> (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) {
+    %0 = "tosa.const"() {value = dense<3.200000e+01> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %1 = "tosa.const"() {value = dense<3.125000e-02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %2 = "tosa.mul"(%arg0, %0) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+    %3 = "tosa.cast"(%2) : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
+    %4 = "tosa.cast"(%3) : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xf32>
+    %5 = "tosa.mul"(%4, %1) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+    // dequantize mul output is used twice, but that can be expected.
+    %6 = "tosa.add"(%arg1, %4) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+    return %5,  %6: tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>
+  }
+}
+
+// --
+
+module attributes {} {
+// CHECK-LABEL:     func.func @multiple_mul_q_uses(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<1x3x4x4xf32>,
+// CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<1x3x4x4xf32>) -> (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) {
+// CHECK:             %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             %[[VAL_3:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             %[[VAL_4:.*]] = "tosa.mul"(%[[VAL_0]], %[[VAL_2]]) <{shift = 0 : i32}> : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_5:.*]] = xten_nn.quantize(%[[VAL_4]] : tensor<1x3x4x4xf32>) {shift = 0 : si32} -> tensor<1x3x4x4xsi8>
+// CHECK:             %[[VAL_6:.*]] = xten_nn.dequantize(%[[VAL_5]] : tensor<1x3x4x4xsi8>) {shift = 0 : si32} -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_7:.*]] = "tosa.mul"(%[[VAL_6]], %[[VAL_3]]) <{shift = 0 : i32}> : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_8:.*]] = "tosa.add"(%[[VAL_1]], %[[VAL_4]]) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return %[[VAL_7]], %[[VAL_8]] : tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>
+// CHECK:           }
+  func.func @multiple_mul_q_uses(%arg0: tensor<1x3x4x4xf32>, %arg1: tensor<1x3x4x4xf32>) -> (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) {
+    %0 = "tosa.const"() {value = dense<3.200000e+01> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %1 = "tosa.const"() {value = dense<3.125000e-02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %2 = "tosa.mul"(%arg0, %0) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+    %3 = "tosa.cast"(%2) : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
+    %4 = "tosa.cast"(%3) : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xf32>
+    %5 = "tosa.mul"(%4, %1) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+    // quantize mul output is used twice this is not allowed, it should only be used by the QuantizeOp
+    %6 = "tosa.add"(%arg1, %2) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+    return %5,  %6: tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>
+  }
+}
+
+// --
+
+module attributes {} {
+// CHECK-LABEL:     func.func @multiple_mul_dq_uses(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<1x3x4x4xf32>,
+// CHECK-SAME:                                      %[[VAL_1:.*]]: tensor<1x3x4x4xf32>) -> (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) {
+// CHECK:             %[[VAL_2:.*]] = xten_nn.quantize(%[[VAL_0]] : tensor<1x3x4x4xf32>) {shift = -5 : si32} -> tensor<1x3x4x4xsi8>
+// CHECK:             %[[VAL_3:.*]] = xten_nn.dequantize(%[[VAL_2]] : tensor<1x3x4x4xsi8>) {shift = -5 : si32} -> tensor<1x3x4x4xf32>
+// CHECK:             %[[VAL_4:.*]] = "tosa.add"(%[[VAL_1]], %[[VAL_3]]) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return %[[VAL_3]], %[[VAL_4]] : tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>
+// CHECK:           }
+  func.func @multiple_mul_dq_uses(%arg0: tensor<1x3x4x4xf32>, %arg1: tensor<1x3x4x4xf32>) -> (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) {
+    %0 = "tosa.const"() {value = dense<3.200000e+01> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %1 = "tosa.const"() {value = dense<3.125000e-02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
+    %2 = "tosa.mul"(%arg0, %0) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+    %3 = "tosa.cast"(%2) : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
+    %4 = "tosa.cast"(%3) : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xf32>
+    %5 = "tosa.mul"(%4, %1) {shift = 0 : i32} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+    // dequantize mul output is used twice, but that can be expected.
+    %6 = "tosa.add"(%arg1, %5) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+    return %5,  %6: tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>
+  }
+}
+
+// --
+
+module attributes {} {
 // CHECK-LABEL:     func.func @broadcast_mul_on_quantize(
 // CHECK-SAME:                               %[[VAL_0:.*]]: tensor<1x3xf32>) -> tensor<4x3xf32> {
 // CHECK:             %[[VAL_1:.*]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<4x3xf32>}> : () -> tensor<4x3xf32>


### PR DESCRIPTION
I noticed in the integration of the TOSA to XTenNN for quantization operations the conversion was to strict and too lax in some places. We want to enforce that the casts we see have only a single use and the first multiplication (quantize scale factor) feeding into the f32->i8 has a single use. 

While the last multiplication (dequantize scalar factor) coming from `DQ->MUL` can have multiple uses. 