### PR TITLE
feat: Add shape inference for the subgraph

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -34,6 +34,8 @@ class XTenNN_Op<string mnemonic, list<Trait> traits = []>
 //===----------------------------------------------------------------------===//
 
 def XTenNN_SubgraphOp : XTenNN_Op<"subgraph", [
+            DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
+                              ["inferReturnTypeComponents"]>,
             SingleBlockImplicitTerminator<"OutputOp">,
             XTenNN_EnclaveOp,
             IsolatedFromAbove,

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -179,6 +179,12 @@ LogicalResult SubgraphOp::inferReturnTypeComponents(
 
   llvm::SmallVector<ShapedTypeComponents, 2> returnShapes;
 
+  // TODO: Ideally, we would walk over the operations in the
+  // subgraph region and have their shapes also inferred by
+  // the InferShapedTypeOpInterface. However, this is enough
+  // for our shape inference because our walk is performed by
+  // another pass. We may need to extend this later if it needs
+  // generalization.
   Operation *terminator = regions.front()->front().getTerminator();
   for (Type type : terminator->getOperandTypes()) {
     auto shapedType = llvm::dyn_cast<ShapedType>(type);

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -171,6 +171,27 @@ LogicalResult SubgraphOp::verify() {
   return success();
 }
 
+LogicalResult SubgraphOp::inferReturnTypeComponents(
+    MLIRContext * /*context*/, ::std::optional<Location> /*location*/,
+    ValueShapeRange /*operands*/, DictionaryAttr /*attributes*/,
+    OpaqueProperties /*properties*/, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes) {
+
+  llvm::SmallVector<ShapedTypeComponents, 2> returnShapes;
+
+  Operation *terminator = regions.front()->front().getTerminator();
+  for (Type type : terminator->getOperandTypes()) {
+    auto shapedType = llvm::dyn_cast<ShapedType>(type);
+
+    if (!shapedType)
+      return failure();
+
+    returnShapes.push_back(shapedType);
+  }
+  inferredReturnShapes.append(returnShapes);
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // XTenNNDialect
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR adds shape inference interface to to the subgraph operation and infer the shape based on the OutputOp.