### PR TITLE
feat: add ops that miss in the tosa standard and add linalg conversion for them

### DIFF
--- a/include/xten/Conversion/Passes.h
+++ b/include/xten/Conversion/Passes.h
@@ -21,6 +21,10 @@
 namespace xilinx {
 namespace xten {
 
+#define GEN_PASS_DECL
+#define GEN_PASS_REGISTRATION
+#include "xten/Conversion/Passes.h.inc"
+
 void registerConversionPasses();
 
 } // namespace xten

--- a/include/xten/Conversion/Passes.td
+++ b/include/xten/Conversion/Passes.td
@@ -72,4 +72,11 @@ def XTenNNToTosa : Pass<"xten-nn-to-tosa", "ModuleOp"> {
   ];
 }
 
+def ConvertXTenNNToLinalg : Pass<"convert-xtennn-to-linalg", "mlir::func::FuncOp"> {
+  let summary = "Convert XTenNN operations to Linalg.";
+  let description = [{
+    Partial conversion of XTenNN operations to Linalg.
+  }];
+}
+
 #endif

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.h
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.h
@@ -23,6 +23,9 @@
 namespace mlir::OpTrait {
 template <typename ConcreteType>
 class TosaExtension : public TraitBase<ConcreteType, TosaExtension> {};
+
+template <typename ConcreteType>
+class ElementwiseUnary : public TraitBase<ConcreteType, ElementwiseUnary> {};
 } // namespace mlir::OpTrait
 
 #define GET_OP_CLASSES

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.h
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.h
@@ -20,6 +20,11 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "xten/Dialect/XTenNN/Interfaces/EnclaveOpInterfaces.h"
 
+namespace mlir::OpTrait {
+template <typename ConcreteType>
+class TosaExtension : public TraitBase<ConcreteType, TosaExtension> {};
+} // namespace mlir::OpTrait
+
 #define GET_OP_CLASSES
 #include "xten/Dialect/XTenNN/IR/XTenNNOps.h.inc"
 

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -181,4 +181,25 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
   let assemblyFormat = [{ attr-dict `->` type($output) }];
 }
 
+//===----------------------------------------------------------------------===//
+// Ops that are missing from the TOSA standard
+//===----------------------------------------------------------------------===//
+
+def TosaExtension : NativeOpTrait<"TosaExtension">;
+
+def XtenNN_UnifiedSignOp: XTenNN_Op<"unified.sign", [Pure, TosaExtension]> {
+  let summary = "Calculate the sign of the given input tensor element-wise";
+  let description = [{
+    Calculate the sign of the given input tensor element-wise. If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
+  }];
+  let arguments = (ins
+    AnyTensor:$input
+  );
+  let results = (outs
+    AnyTensor:$output
+  );
+
+  let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
+}
+
 #endif // XTENNN_OPS

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -192,6 +192,7 @@ def XtenNN_UnifiedSignOp: XTenNN_Op<"unified.sign", [Pure, TosaExtension, Elemen
   let summary = "Calculate the sign of the given input tensor element-wise";
   let description = [{
     Calculate the sign of the given input tensor element-wise. If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
+    If the input is a NaN, the output will be a copy of the input element.
   }];
   let arguments = (ins
     AnyTensor:$input

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -186,8 +186,9 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
 //===----------------------------------------------------------------------===//
 
 def TosaExtension : NativeOpTrait<"TosaExtension">;
+def ElementwiseUnary : NativeOpTrait<"ElementwiseUnary">;
 
-def XtenNN_UnifiedSignOp: XTenNN_Op<"unified.sign", [Pure, TosaExtension]> {
+def XtenNN_UnifiedSignOp: XTenNN_Op<"unified.sign", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
   let summary = "Calculate the sign of the given input tensor element-wise";
   let description = [{
     Calculate the sign of the given input tensor element-wise. If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -188,7 +188,7 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
 def TosaExtension : NativeOpTrait<"TosaExtension">;
 def ElementwiseUnary : NativeOpTrait<"ElementwiseUnary">;
 
-def XtenNN_UnifiedSignOp: XTenNN_Op<"unified.sign", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
+def XtenNN_SignOp: XTenNN_Op<"sign", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
   let summary = "Calculate the sign of the given input tensor element-wise";
   let description = [{
     Calculate the sign of the given input tensor element-wise. If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -13,6 +13,7 @@ TosaToXTenNN.cpp
 XTenToAffine.cpp
 XTenToLinalg.cpp
 XTenNNToTosa.cpp
+XTenNNToLinalg.cpp
 
 DEPENDS
 XTenConversionIncGen

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -10,9 +10,5 @@
 
 #include "xten/Conversion/Passes.h"
 
-namespace {
-#define GEN_PASS_REGISTRATION
-#include "xten/Conversion/Passes.h.inc"
-}
 
-void xilinx::xten::registerConversionPasses() { ::registerXTenConversionPasses(); }
+void xilinx::xten::registerConversionPasses() { registerXTenConversionPasses(); }

--- a/lib/Conversion/XTenNNToLinalg.cpp
+++ b/lib/Conversion/XTenNNToLinalg.cpp
@@ -103,12 +103,12 @@ Value mapSignOpToStdScalarOp(Location loc, ArrayRef<Type> resultTypes,
   return nullptr;
 }
 
-class UnifiedSignToLinalg : public OpConversionPattern<UnifiedSignOp> {
+class SignToLinalg : public OpConversionPattern<SignOp> {
 public:
-  using OpConversionPattern<UnifiedSignOp>::OpConversionPattern;
-  using OpAdaptor = typename UnifiedSignOp::Adaptor;
+  using OpConversionPattern<SignOp>::OpConversionPattern;
+  using OpAdaptor = typename SignOp::Adaptor;
   LogicalResult
-  matchAndRewrite(UnifiedSignOp op, OpAdaptor adaptor,
+  matchAndRewrite(SignOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
     ValueRange inputs = adaptor.getOperands();
@@ -166,14 +166,14 @@ struct ConvertXtenNNtoLinalg
     auto funcOp = getOperation();
 
     ConversionTarget target(*context);
-    target.addIllegalOp<UnifiedSignOp>();
+    target.addIllegalOp<SignOp>();
     target.addLegalDialect<linalg::LinalgDialect, scf::SCFDialect,
                            complex::ComplexDialect, math::MathDialect,
                            shape::ShapeDialect, tensor::TensorDialect,
                            arith::ArithDialect>();
 
     RewritePatternSet patterns(context);
-    patterns.add<UnifiedSignToLinalg>(context);
+    patterns.add<SignToLinalg>(context);
 
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns))))
       signalPassFailure();

--- a/lib/Conversion/XTenNNToLinalg.cpp
+++ b/lib/Conversion/XTenNNToLinalg.cpp
@@ -1,0 +1,177 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/Utils/ConversionUtils.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "xten/Dialect/XTenNN/IR/XTenNNOps.h"
+
+namespace xilinx::xten {
+#define GEN_PASS_DECL_CONVERTXTENNNTOLINALG
+#define GEN_PASS_DEF_CONVERTXTENNNTOLINALG
+#include "xten/Conversion/Passes.h.inc"
+} // namespace xilinx::xten
+
+using namespace mlir;
+using namespace amd::xten_nn;
+
+namespace {
+
+int64_t getRank(Value v) {
+  return cast<ShapedType>(v.getType()).getRank();
+}
+
+int64_t getMaxRank(ValueRange operands) {
+  int64_t maxRank = 0;
+  for (Value operand : operands) {
+    maxRank = std::max(maxRank, getRank(operand));
+  }
+  return maxRank;
+}
+
+bool isScalar(Value v) {
+  return getRank(v) == 0;
+}
+
+Value getEmptyTensor(OpBuilder &b, Location loc, ShapedType type,
+                     ArrayRef<Value> dynSizes) {
+  return b.create<tensor::EmptyOp>(loc, type.getShape(), type.getElementType(),
+                                   dynSizes,
+                                   type.cast<RankedTensorType>().getEncoding());
+}
+
+inline Value getConstantOrSplat(OpBuilder *b, Location loc, Type t,
+                                Attribute v) {
+  if (VectorType vecType = t.dyn_cast<VectorType>()) {
+    v = SplatElementsAttr::get(vecType, v);
+  }
+  return b->create<arith::ConstantOp>(loc, t, cast<TypedAttr>(v));
+}
+
+Value mapSignOpToStdScalarOp(Location loc, ArrayRef<Type> resultTypes,
+                             Value operand, OpBuilder *b) {
+  Type elementType = getElementTypeOrSelf(operand.getType());
+  if (auto floatType = elementType.dyn_cast<FloatType>()) {
+    Value zero =
+        b->create<arith::ConstantOp>(loc, b->getZeroAttr(operand.getType()));
+    Value ne0I1 = b->create<::mlir::arith::CmpFOp>(
+        loc, arith::CmpFPredicate::ONE, operand, zero);
+    Value ne0Float =
+        b->create<::mlir::arith::UIToFPOp>(loc, zero.getType(), ne0I1);
+    Value copySign = b->create<::mlir::math::CopySignOp>(loc, resultTypes,
+                                                         ne0Float, operand);
+    auto isNan = b->create<::mlir::arith::CmpFOp>(
+        loc, arith::CmpFPredicate::UNO, operand, operand);
+    return b->create<::mlir::arith::SelectOp>(loc, isNan, operand, copySign);
+  }
+  if (auto integerType = elementType.dyn_cast<IntegerType>()) {
+    // sign(x) = x == 0 ? 0 : ((x s>> 31) | 1)
+    Value zero =
+        b->create<arith::ConstantOp>(loc, b->getZeroAttr(operand.getType()));
+    Value bitwidthMinusOne = getConstantOrSplat(
+        b, loc, operand.getType(),
+        b->getIntegerAttr(integerType, integerType.getWidth() - 1));
+    Value one = getConstantOrSplat(b, loc, operand.getType(),
+                                   b->getIntegerAttr(integerType, 1));
+    Value cmp = b->create<::mlir::arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                 operand, zero);
+    Value ashr =
+        b->create<::mlir::arith::ShRSIOp>(loc, operand, bitwidthMinusOne);
+    Value orOp = b->create<::mlir::arith::OrIOp>(loc, ashr, one);
+    return b->create<::mlir::arith::SelectOp>(loc, cmp, zero, orOp);
+  }
+  if (elementType.isa<ComplexType>()) {
+    return b->create<::mlir::complex::SignOp>(loc, elementType, operand);
+  }
+  return nullptr;
+}
+
+class UnifiedSignToLinalg : public OpConversionPattern<UnifiedSignOp> {
+public:
+  using OpConversionPattern<UnifiedSignOp>::OpConversionPattern;
+  using OpAdaptor = typename UnifiedSignOp::Adaptor;
+  LogicalResult
+  matchAndRewrite(UnifiedSignOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    ValueRange inputs = adaptor.getOperands();
+    auto resultTy = cast<ShapedType>(op.getOutput().getType());
+    Value output = getEmptyTensor(rewriter, loc, resultTy, {});
+
+    int64_t maxRank = getMaxRank(adaptor.getOperands());
+
+    // Create indexing maps.
+    AffineMap scalarMap = AffineMap::get(maxRank, 0, rewriter.getContext());
+    AffineMap idMap = rewriter.getMultiDimIdentityMap(maxRank);
+    SmallVector<AffineMap> maps;
+    for (Value v : inputs)
+      maps.push_back(isScalar(v) ? scalarMap : idMap);
+    maps.push_back(idMap);
+    // Build `linalg.generic` op.
+    bool failed = false;
+    auto linalgOp = rewriter.create<linalg::GenericOp>(
+        loc, resultTy ? resultTy : TypeRange{}, inputs, output, maps,
+        mlir::tosa::getNParallelLoopsAttrs(maxRank),
+        [&](OpBuilder &nestedBuilder, Location /*nested_loc*/,
+            ValueRange args) {
+          Type innerResultTy = getElementTypeOrSelf(output);
+          Value innerResult = mapSignOpToStdScalarOp(loc, innerResultTy,
+                                                     args.front(), &rewriter);
+          if (!innerResult) {
+            failed = true;
+          } else {
+            nestedBuilder.create<linalg::YieldOp>(loc, innerResult);
+          }
+        },
+        linalg::getPrunedAttributeList(op));
+    if (failed)
+      return failure();
+
+    rewriter.replaceOp(op, linalgOp.getResults());
+    return success();
+  }
+};
+
+struct ConvertXtenNNtoLinalg
+    : public xilinx::xten::impl::ConvertXTenNNToLinalgBase<
+          ConvertXtenNNtoLinalg> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<linalg::LinalgDialect, scf::SCFDialect, complex::ComplexDialect,
+                math::MathDialect, shape::ShapeDialect, tensor::TensorDialect,
+                arith::ArithDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    auto funcOp = getOperation();
+
+    ConversionTarget target(*context);
+    target.addIllegalOp<UnifiedSignOp>();
+    target.addLegalDialect<linalg::LinalgDialect, scf::SCFDialect,
+                           complex::ComplexDialect, math::MathDialect,
+                           shape::ShapeDialect, tensor::TensorDialect,
+                           arith::ArithDialect>();
+
+    RewritePatternSet patterns(context);
+    patterns.add<UnifiedSignToLinalg>(context);
+
+    if (failed(applyPartialConversion(funcOp, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/test/Conversion/XTenNNToLinalg/Sign.mlir
+++ b/test/Conversion/XTenNNToLinalg/Sign.mlir
@@ -1,7 +1,7 @@
 // RUN: aten-opt --convert-xtennn-to-linalg %s | FileCheck %s
 
 func.func @sign(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
-    %0 = xten_nn.unified.sign %arg0 : (tensor<1x10xf32>) -> tensor<1x10xf32>
+    %0 = xten_nn.sign %arg0 : (tensor<1x10xf32>) -> tensor<1x10xf32>
     return %0 : tensor<1x10xf32>
 // CHECK-LABEL:   func.func @sign(
 // CHECK-SAME:                    %[[VAL_0:.*]]: tensor<1x10xf32>) -> tensor<1x10xf32> {
@@ -22,7 +22,7 @@ func.func @sign(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
 // -----
 
 func.func @sign_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
-    %0 = xten_nn.unified.sign %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
+    %0 = xten_nn.sign %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
     return %0 : tensor<1x10xi4>
 // CHECK-LABEL:   func.func @sign_int(
 // CHECK-SAME:                        %[[VAL_0:.*]]: tensor<1x10xi4>) -> tensor<1x10xi4> {
@@ -44,7 +44,7 @@ func.func @sign_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
 // -----
 
 func.func @sign_complex(%arg0: tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>> {
-    %0 = xten_nn.unified.sign %arg0 : (tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>>
+    %0 = xten_nn.sign %arg0 : (tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>>
     return %0 : tensor<1x10xcomplex<f32>>
 // CHECK-LABEL:   func.func @sign_complex(
 // CHECK-SAME:                            %[[VAL_0:.*]]: tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>> {

--- a/test/Conversion/XTenNNToLinalg/Sign.mlir
+++ b/test/Conversion/XTenNNToLinalg/Sign.mlir
@@ -1,0 +1,58 @@
+// RUN: aten-opt --convert-xtennn-to-linalg %s | FileCheck %s
+
+func.func @sign(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
+    %0 = xten_nn.unified.sign %arg0 : (tensor<1x10xf32>) -> tensor<1x10xf32>
+    return %0 : tensor<1x10xf32>
+// CHECK-LABEL:   func.func @sign(
+// CHECK-SAME:                    %[[VAL_0:.*]]: tensor<1x10xf32>) -> tensor<1x10xf32> {
+// CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xf32>
+// CHECK:           %[[VAL_2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_0]] : tensor<1x10xf32>) outs(%[[VAL_1]] : tensor<1x10xf32>) {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: f32):
+// CHECK:             %[[VAL_5:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:             %[[VAL_6:.*]] = arith.cmpf one, %[[VAL_3]], %[[VAL_5]] : f32
+// CHECK:             %[[VAL_7:.*]] = arith.uitofp %[[VAL_6]] : i1 to f32
+// CHECK:             %[[VAL_8:.*]] = math.copysign %[[VAL_7]], %[[VAL_3]] : f32
+// CHECK:             %[[VAL_9:.*]] = arith.cmpf uno, %[[VAL_3]], %[[VAL_3]] : f32
+// CHECK:             %[[VAL_10:.*]] = arith.select %[[VAL_9]], %[[VAL_3]], %[[VAL_8]] : f32
+// CHECK:             linalg.yield %[[VAL_10]] : f32
+// CHECK:           } -> tensor<1x10xf32>
+// CHECK:           return %[[VAL_11:.*]] : tensor<1x10xf32>
+}
+
+// -----
+
+func.func @sign_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
+    %0 = xten_nn.unified.sign %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
+    return %0 : tensor<1x10xi4>
+// CHECK-LABEL:   func.func @sign_int(
+// CHECK-SAME:                        %[[VAL_0:.*]]: tensor<1x10xi4>) -> tensor<1x10xi4> {
+// CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xi4>
+// CHECK:           %[[VAL_2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_0]] : tensor<1x10xi4>) outs(%[[VAL_1]] : tensor<1x10xi4>) {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: i4, %[[VAL_4:.*]]: i4):
+// CHECK:             %[[VAL_5:.*]] = arith.constant 0 : i4
+// CHECK:             %[[VAL_6:.*]] = arith.constant 3 : i4
+// CHECK:             %[[VAL_7:.*]] = arith.constant 1 : i4
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi eq, %[[VAL_3]], %[[VAL_5]] : i4
+// CHECK:             %[[VAL_9:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_6]] : i4
+// CHECK:             %[[VAL_10:.*]] = arith.ori %[[VAL_9]], %[[VAL_7]] : i4
+// CHECK:             %[[VAL_11:.*]] = arith.select %[[VAL_8]], %[[VAL_5]], %[[VAL_10]] : i4
+// CHECK:             linalg.yield %[[VAL_11]] : i4
+// CHECK:           } -> tensor<1x10xi4>
+// CHECK:           return %[[VAL_12:.*]] : tensor<1x10xi4>
+}
+
+// -----
+
+func.func @sign_complex(%arg0: tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>> {
+    %0 = xten_nn.unified.sign %arg0 : (tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>>
+    return %0 : tensor<1x10xcomplex<f32>>
+// CHECK-LABEL:   func.func @sign_complex(
+// CHECK-SAME:                            %[[VAL_0:.*]]: tensor<1x10xcomplex<f32>>) -> tensor<1x10xcomplex<f32>> {
+// CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xcomplex<f32>>
+// CHECK:           %[[VAL_2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_0]] : tensor<1x10xcomplex<f32>>) outs(%[[VAL_1]] : tensor<1x10xcomplex<f32>>) {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: complex<f32>, %[[VAL_4:.*]]: complex<f32>):
+// CHECK:             %[[VAL_5:.*]] = complex.sign %[[VAL_3]] : complex<f32>
+// CHECK:             linalg.yield %[[VAL_5]] : complex<f32>
+// CHECK:           } -> tensor<1x10xcomplex<f32>>
+// CHECK:           return %[[VAL_6:.*]] : tensor<1x10xcomplex<f32>>
+}


### PR DESCRIPTION
I added a new dialect "namespace" for this extension. A follow up story might be to rename the quantization ops to this scheme.

Also added new Traits for a bit of a taxonomy when working with them. The `ToseExtension Trait` can be converted to an interface if the TOSA decomposition is needed.