### PR TITLE
TosaToXTenNN: Don't sort all commutative ops

### DIFF
--- a/lib/Conversion/TosaToXTenNN.cpp
+++ b/lib/Conversion/TosaToXTenNN.cpp
@@ -13,7 +13,6 @@
 #include "xten/Dialect/XTenNN/IR/XTenNNOps.h"
 
 #include "mlir/IR/Matchers.h"
-#include "mlir/Transforms/CommutativityUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace mlir;
@@ -290,8 +289,6 @@ public:
     MLIRContext *context = module.getContext();
     RewritePatternSet patterns(context);
 
-    // Ensures constants on the add, mul, sub are on the RHS
-    populateCommutativityUtilsPatterns(patterns);
     // Patterns for finding the QDQ and folding MULs.
     patterns
         .insert<MoveScalarTensorToRHSOfMul, CastsToQDQOps, FoldMulsToQDQOps>(


### PR DESCRIPTION
There is already a pattern for moving the scalar to the RHS of the mul (see MoveScalarTensorToRHSOfMul below), so there is no need to do so general changes to the IR.

All the existing lit tests are still passing for this pass, so it really seemed to be not needed.