### PR TITLE
feat: add support for round operation that mappes to math.roundeven.

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -188,14 +188,16 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
 def TosaExtension : NativeOpTrait<"TosaExtension">;
 def ElementwiseUnary : NativeOpTrait<"ElementwiseUnary">;
 
-def XtenNN_SignOp: XTenNN_Op<"sign", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
-  let summary = "Calculate the sign of the given input tensor element-wise";
+def XtenNN_EluOp: XTenNN_Op<"elu", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
+  let summary = "Calculate the elu operation of the given input tensor element-wise";
   let description = [{
-    Calculate the sign of the given input tensor element-wise. If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
-    If the input is a NaN, the output will be a copy of the input element.
+    Calculate the elu operation (Exponential Linear Unit) of the given input tensor element-wise.
+    ELU(x) =  x,                  if x >  0
+              alpha * (exp(x)-1), if x <= 0
   }];
   let arguments = (ins
-    AnyTensor:$input
+    AnyTensor:$input,
+    F32Attr:$alpha
   );
   let results = (outs
     AnyTensor:$output
@@ -219,16 +221,30 @@ def XtenNN_MishOp: XTenNN_Op<"mish", [Pure, TosaExtension, ElementwiseUnary, Sam
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
 }
 
-def XtenNN_EluOp: XTenNN_Op<"elu", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
-  let summary = "Calculate the elu operation of the given input tensor element-wise";
+def XtenNN_RoundOp: XTenNN_Op<"round", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
+  let summary = "Calculate the round operation of the given input tensor element-wise.";
   let description = [{
-    Calculate the elu operation (Exponential Linear Unit) of the given input tensor element-wise.
-    ELU(x) =  x,                  if x >  0
-              alpha * (exp(x)-1), if x <= 0
+    Calculate the round operation of the given input tensor element-wise.
+    In case of halves, the rule is to round them to the nearest even integer as does the 'round' operation in torch and onnx.
   }];
   let arguments = (ins
-    AnyTensor:$input,
-    F32Attr:$alpha
+    AnyTensor:$input
+  );
+  let results = (outs
+    AnyTensor:$output
+  );
+
+  let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
+}
+
+def XtenNN_SignOp: XTenNN_Op<"sign", [Pure, TosaExtension, ElementwiseUnary, SameOperandsAndResultElementType]> {
+  let summary = "Calculate the sign of the given input tensor element-wise";
+  let description = [{
+    Calculate the sign of the given input tensor element-wise. If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
+    If the input is a NaN, the output will be a copy of the input element.
+  }];
+  let arguments = (ins
+    AnyTensor:$input
   );
   let results = (outs
     AnyTensor:$output

--- a/test/Conversion/XTenNNToLinalg/Round.mlir
+++ b/test/Conversion/XTenNNToLinalg/Round.mlir
@@ -1,0 +1,30 @@
+// RUN: aten-opt --convert-xtennn-to-linalg %s | FileCheck %s
+
+func.func @round(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
+    %0 = xten_nn.round %arg0 : (tensor<1x10xf32>) -> tensor<1x10xf32>
+    return %0 : tensor<1x10xf32>
+// CHECK-LABEL:   func.func @round(
+// CHECK-SAME:                    %[[VAL_0:.*]]: tensor<1x10xf32>) -> tensor<1x10xf32> {
+// CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xf32>
+// CHECK:           %[[VAL_2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_0]] : tensor<1x10xf32>) outs(%[[VAL_1]] : tensor<1x10xf32>) {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: f32):
+// CHECK:             %[[VAL_4:.*]] = math.roundeven %[[VAL_3]] : f32
+// CHECK:             linalg.yield %[[VAL_4]] : f32
+// CHECK:           } -> tensor<1x10xf32>
+// CHECK:           return %[[VAL_2:.*]] : tensor<1x10xf32>
+}
+
+// -----
+
+func.func @round_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
+    %0 = xten_nn.round %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
+    return %0 : tensor<1x10xi4>
+// CHECK-LABEL:   func.func @round_int(
+// CHECK-SAME:                        %[[VAL_0:.*]]: tensor<1x10xi4>) -> tensor<1x10xi4> {
+// CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xi4>
+// CHECK:           %[[VAL_2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_0]] : tensor<1x10xi4>) outs(%[[VAL_1]] : tensor<1x10xi4>) {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: i4, %[[VAL_4:.*]]: i4):
+// CHECK:             linalg.yield %[[VAL_3]] : i4
+// CHECK:           } -> tensor<1x10xi4>
+// CHECK:           return %[[VAL_2:.*]] : tensor<1x10xi4>
+}

--- a/test/Conversion/XTenNNToLinalg/Round.mlir
+++ b/test/Conversion/XTenNNToLinalg/Round.mlir
@@ -1,8 +1,9 @@
-// RUN: aten-opt --convert-xtennn-to-linalg %s | FileCheck %s
+// RUN: aten-opt --convert-xtennn-to-linalg -split-input-file %s | FileCheck %s
 
 func.func @round(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
     %0 = xten_nn.round %arg0 : (tensor<1x10xf32>) -> tensor<1x10xf32>
     return %0 : tensor<1x10xf32>
+// CHECK: #map = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:   func.func @round(
 // CHECK-SAME:                    %[[VAL_0:.*]]: tensor<1x10xf32>) -> tensor<1x10xf32> {
 // CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xf32>
@@ -16,9 +17,27 @@ func.func @round(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
 
 // -----
 
+func.func @round_bf16(%arg0: tensor<1x10xbf16>) -> tensor<1x10xbf16> {
+    %0 = xten_nn.round %arg0 : (tensor<1x10xbf16>) -> tensor<1x10xbf16>
+    return %0 : tensor<1x10xbf16>
+// CHECK: #map = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:   func.func @round_bf16(
+// CHECK-SAME:                    %[[VAL_0:.*]]: tensor<1x10xbf16>) -> tensor<1x10xbf16> {
+// CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xbf16>
+// CHECK:           %[[VAL_2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_0]] : tensor<1x10xbf16>) outs(%[[VAL_1]] : tensor<1x10xbf16>) {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: bf16, %[[VAL_4:.*]]: bf16):
+// CHECK:             %[[VAL_4:.*]] = math.roundeven %[[VAL_3]] : bf16
+// CHECK:             linalg.yield %[[VAL_4]] : bf16
+// CHECK:           } -> tensor<1x10xbf16>
+// CHECK:           return %[[VAL_2:.*]] : tensor<1x10xbf16>
+}
+
+// -----
+
 func.func @round_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
     %0 = xten_nn.round %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
     return %0 : tensor<1x10xi4>
+// CHECK: #map = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:   func.func @round_int(
 // CHECK-SAME:                        %[[VAL_0:.*]]: tensor<1x10xi4>) -> tensor<1x10xi4> {
 // CHECK:           %[[VAL_1:.*]] = tensor.empty() : tensor<1x10xi4>


### PR DESCRIPTION
It also reorders the operations in `.td` and the lowering pass so that it doesn't cause too many conflicts for followed operations.